### PR TITLE
Added settings file as a build artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,11 @@ jobs:
       - name: Package
         run: |
           mv build/Release/stfc-community-patch.dll version.dll
-  
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@v4
         with:
           name: stfc-community-patch
-          path: version.dll
+          path: |
+            version.dll
+            example_community_patch_settings.toml
+      

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,9 @@ name: Build and test
 
 on:
   push:
-    branches: [ "v0.5" ]
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
I think the settings file should belong in the delivered artifact. Without it the game doesnt work. Its also usefull when you want to try an old build, you wont have to look up the settings file belonging to the release.

I can edit the PR to add it to the release workflow if you want.
