### PR TITLE
Update sync.cc to propagate resources when their amount drops to 0

### DIFF
--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -603,10 +603,13 @@ void HandleEntityGroup(EntityGroup* entity_group)
         for (const auto& resource : result["resources"].get<json::object_t>()) {
           auto id     = std::stoll(resource.first);
           auto amount = resource.second["current_amount"].get<int64_t>();
-          if (amount == 0 && !resource_states.contains(id)) {
-            continue;
-          }
-          if (resource_states[id] != amount) {
+
+          const auto prevResourceAmountIter = resource_states.find(id);
+          const auto hadResource = (prevResourceAmountIter != resource_states.end() && prevResourceAmountIter->second != 0);
+          const auto amountChanged = amount > 0 && (prevResourceAmountIter == resource_states.end() || prevResourceAmountIter->second != amount);
+          const auto resourceDepleted = hadResource && amount == 0;
+
+          if (resourceDepleted || amountChanged) {
             resource_states[id] = amount;
             resource_array.push_back({{"type", "resource"}, {"rid", id}, {"amount", amount}});
           }

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -603,7 +603,7 @@ void HandleEntityGroup(EntityGroup* entity_group)
         for (const auto& resource : result["resources"].get<json::object_t>()) {
           auto id     = std::stoll(resource.first);
           auto amount = resource.second["current_amount"].get<int64_t>();
-          if (amount == 0) {
+          if (amount == 0 && !resource_states.contains(id)) {
             continue;
           }
           if (resource_states[id] != amount) {


### PR DESCRIPTION
When all resources are spent, i.e. you use all your resource tokens for an upgrade, the amount of resources in inventory doesn't get pushed to sync endpoints. This PR partially addresses this problem by propagating those resources if they previously had a non-zero value.