### PR TITLE
Add X-Instance-ID header

### DIFF
--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -266,7 +266,7 @@ static std::wstring get_data_data(std::wstring session, std::wstring url, std::w
     list = sync_slist_append(CURL_TYPE_DOWNLOAD, list, "X-Api-Key", PRIME_API_KEY);
     list = sync_slist_append(CURL_TYPE_DOWNLOAD, list, "X-Unity-Version", UNITY_VERSION);
     list = sync_slist_append(CURL_TYPE_DOWNLOAD, list, "X-PRIME-VERSION", PRIME_VERSION);
-    list = sync_slist_append(CURL_TYPE_DOWNLOAD, list, "X-Instance-ID", std::to_string(instanceId).c_str());
+    list = sync_slist_append(CURL_TYPE_DOWNLOAD, list, "X-Instance-ID", std::format("{:03}", instanceId));
     list = sync_slist_append(CURL_TYPE_DOWNLOAD, list, "X-PRIME-SYNC", "0");
     list = sync_slist_append(CURL_TYPE_DOWNLOAD, list, "X-Suppress-Codes", "1");
     list = sync_slist_append(CURL_TYPE_DOWNLOAD, list, "User-Agent", user_agent);


### PR DESCRIPTION
Due to the recent switch to generic/regional URLs, an instance-specific header is now required