### PR TITLE
Allow passing a configuration filename [WIN-ONLY]

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -281,6 +281,20 @@ void parse_config_shortcut(toml::table config, toml::table& new_config, std::str
   spdlog::info("shortcut value {}.{} value: {}", section, item, shortcut);
 }
 
+#if _WIN32
+std::string ConvertWStringToString(const std::wstring& wstr)
+{
+  if (wstr.empty())
+    return std::string();
+
+  int         sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), nullptr, 0, nullptr, nullptr);
+  std::string str(sizeNeeded, 0);
+  WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &str[0], sizeNeeded, nullptr, nullptr);
+
+  return str;
+}
+#endif
+
 std::string_view Config::Filename()
 {
   static std::string configFile = "";
@@ -307,7 +321,7 @@ std::string_view Config::Filename()
       }
 
       if (!argValue.empty()) {
-        configFile.assign(argValue.begin(), argValue.end());
+        configFile = ConvertWStringToString(argValue);
       }
 
       // Clean up

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -17,6 +17,8 @@ public:
   static float   GetDPI();
   static float   RefreshDPI();
 
+  static std::string_view Filename();
+
   static void Save(toml::table config, std::string_view filename, bool apply_warning = true);
   void        Load();
   void        AdjustUiScale(bool scaleUp);

--- a/win-proxy-dll/xmake.lua
+++ b/win-proxy-dll/xmake.lua
@@ -9,6 +9,7 @@ do
     set_exceptions("cxx")
     if is_plat("windows") then
         add_cxflags("/bigobj")
+        add_links("Shell32.lib")
     end
     set_policy("build.optimization.lto", true)
     add_links("User32.lib", "Ole32.lib", "OleAut32.lib")


### PR DESCRIPTION
This allow windows users to pass a configuration file vka te command line option "-ccm" and using the following value as a filename.  