### PR TITLE
Support for multiple sync targets

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -63,12 +63,6 @@ vsync = 1
 zoom = 2500
 
 [sync]
-# Token for auth on remote system
-token = ''
-
-# Url to post sync data to
-url = ''
-
 # Do you want to sync battlelogs?
 battlelogs = false
 
@@ -96,6 +90,13 @@ tech = false
 # Do you want to sync trait data?
 traits = false
 
+    [sync.target.default]
+    # Token for auth on remote system
+    token = ''
+
+    # Url to post sync data to
+    url = ''
+
 
 [tech]
 # NOTE: The following is currently disabled in InstallWebRequestHooks() which instantly returns
@@ -118,7 +119,7 @@ disable_toast_banners = true
 # This specifies the types of Banners you DON'T want to see, This must be a comma seperated list enclosed in single quotes.
 disabled_banner_types = 'Event,Victory,Defeat'
 
-# Here is a list of POSSIBLE Banner types, I think they are relatively self explanatory.
+# Here is a list of POSSIBLE Banner types, I think they are relatively self-explanatory.
 #
 # Standard
 # FactionWarning

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -464,9 +464,13 @@ void Config::Load()
   auto sync_token = config["sync"]["token"].value<std::string>();
 
   if (sync_url.has_value() && sync_token.has_value()) {
-    if (this->sync_targets.emplace(sync_url.value(), sync_url.value()).second) {
+    spdlog::warn("Depreciation Warning: Legacy config options 'sync_url' and 'sync_token' have been moved to [sync.targets.<name>] sections and may be removed in a future version.");
+
+    if (this->sync_targets.emplace(sync_url.value(), sync_token.value()).second) {
       parsed["sync"]["targets"].as_table()->emplace<toml::table>("default", toml::table{ {"url", sync_url.value()}, {"token", sync_token.value()} });
-      spdlog::info("config value sync.targets.default url: {}, token: {}", sync_url.value(), sync_token.value());
+      spdlog::info("Legacy config options 'sync_url' and 'sync_token' were converted to sync.targets.default url: {}, token: {}", sync_url.value(), sync_token.value());
+    } else {
+      spdlog::error("Failed to convert legacy config options sync_url: {} and sync_token: {} as [sync.targets.default] was already specified.", sync_url.value(), sync_token.value());
     }
   }
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -297,6 +297,8 @@ void Config::Load()
   this->use_scopely_hotkeys = get_config_or_default(config, parsed, "control", "use_scopely_hotkeys", false);
 #if DEBUG
   this->enable_experimental = get_config_or_default(config, parsed, "control", "enable_experimental", false);
+#else
+  this->enable_experimental = false;
 #endif
 
   this->ui_scale            = get_config_or_default(config, parsed, "graphics", "ui_scale", 0.9f);
@@ -351,10 +353,8 @@ void Config::Load()
 
   this->fix_unity_web_requests = get_config_or_default(config, parsed, "tech", "fix_unity_web_requests", true);
 
-  this->sync_url        = get_config_or_default<std::string>(config, parsed, "sync", "url", "");
   this->sync_proxy      = get_config_or_default<std::string>(config, parsed, "sync", "proxy", "");
   this->sync_file       = get_config_or_default<std::string>(config, parsed, "sync", "file", "");
-  this->sync_token      = get_config_or_default<std::string>(config, parsed, "sync", "token", "");
   this->sync_logging    = get_config_or_default(config, parsed, "sync", "logging", false);
   this->sync_battlelogs = get_config_or_default(config, parsed, "sync", "battlelogs", false);
   this->sync_resources  = get_config_or_default(config, parsed, "sync", "resources", false);
@@ -366,7 +366,43 @@ void Config::Load()
   this->sync_buildings  = get_config_or_default(config, parsed, "sync", "buildings", false);
   this->sync_ships      = get_config_or_default(config, parsed, "sync", "ships", false);
 
-  // must explicitly included std::string typing here or we get back char * which fails us!
+  config["sync"].as_table()->emplace<toml::table>("targets", toml::table());
+  parsed["sync"].as_table()->emplace<toml::table>("targets", toml::table());
+
+  for (const auto& sync_iter : *config["sync"]["targets"].as_table()) {
+    if (!sync_iter.second.is_table()) {
+      continue;
+    }
+
+    const auto& values = *sync_iter.second.as_table();
+    if (!values.contains("url") || !values.contains("token")) {
+      continue;
+    }
+
+    auto key = sync_iter.first.str();
+    auto url = values["url"].value<std::string>();
+    auto token = values["token"].value<std::string>();
+
+    if (url.has_value() && token.has_value()) {
+      if (this->sync_targets.emplace(url.value(), token.value()).second) {
+        parsed["sync"]["targets"].as_table()->emplace<toml::table>(key, toml::table{ {"url", url.value()}, {"token", token.value()} });
+        spdlog::info("config value sync.targets.{} url: {}, token: {}", key, url.value(), token.value());
+      }
+    }
+  }
+
+  // handle legacy sync options
+  auto sync_url = config["sync"]["url"].value<std::string>();
+  auto sync_token = config["sync"]["token"].value<std::string>();
+
+  if (sync_url.has_value() && sync_token.has_value()) {
+    if (this->sync_targets.emplace(sync_url.value(), sync_url.value()).second) {
+      parsed["sync"]["targets"].as_table()->emplace<toml::table>("default", toml::table{ {"url", sync_url.value()}, {"token", sync_token.value()} });
+      spdlog::info("config value sync.targets.default url: {}, token: {}", sync_url.value(), sync_token.value());
+    }
+  }
+
+  // must explicitly include std::string typing here, or we get back char * which fails us!
   std::string disabled_banner_types_str =
       get_config_or_default<std::string>(config, parsed, "ui", "disabled_banner_types", "");
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -17,6 +17,9 @@
 
 #if !_WIN32
 #include "folder_manager.h"
+#else
+#include <shellapi.h>
+#include <windows.h>
 #endif
 
 static auto make_config_path(auto filename, bool create_dir = false)
@@ -76,8 +79,9 @@ void Config::Save(toml::table config, std::string_view filename, bool apply_warn
 
   config_file.open(config_path);
   if (apply_warning) {
-    char buff[44];
-    snprintf(buff, 44, "%-44s", CONFIG_FILE_DEFAULT);
+    char defaultFile[44], configFile[44];
+    snprintf(defaultFile, 44, "%-44s", CONFIG_FILE_DEFAULT);
+    snprintf(configFile, 44, "%-44s", Config::Filename());
 
     config_file << "#######################################################################\n";
     config_file << "#######################################################################\n";
@@ -86,11 +90,14 @@ void Config::Save(toml::table config, std::string_view filename, bool apply_warn
     config_file << "####       by the STFC community patch.  It is provided to help    ####\n";
     config_file << "####       see what configuration is being used by the runtime     ####\n";
     config_file << "####       and any desired settings should be copied to the same   ####\n";
-    config_file << "####       section in: " << buff << " ####\n";
+    config_file << "####       section in: " << defaultFile << " ####\n";
+    config_file << "####                                                               ####\n";
+    config_file << "####        Config in: " << configFile << " ####\n";
     config_file << "####                                                               ####\n";
     config_file << "#######################################################################\n";
     config_file << "#######################################################################\n\n";
-  }
+  } 
+
   config_file << config;
   config_file.close();
 }
@@ -274,15 +281,76 @@ void parse_config_shortcut(toml::table config, toml::table& new_config, std::str
   spdlog::info("shortcut value {}.{} value: {}", section, item, shortcut);
 }
 
+#if _WIN32
+std::string ConvertWStringToString(const std::wstring& wstr)
+{
+  if (wstr.empty())
+    return std::string();
+
+  int         sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), nullptr, 0, nullptr, nullptr);
+  std::string str(sizeNeeded, 0);
+  WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &str[0], sizeNeeded, nullptr, nullptr);
+
+  return str;
+}
+#endif
+
+std::string_view Config::Filename()
+{
+  static std::string configFile = "";
+
+  if (configFile.empty()) {
+#if _WIN32
+    // Get the command line
+    LPCWSTR cmdLine = GetCommandLineW();
+
+    // Parse command line into individual arguments
+    int     argc;
+    LPWSTR* argv = CommandLineToArgvW(cmdLine, &argc);
+
+    // If we have some arguments, lets see what we got
+    std::wstring argValue;
+    if (argv != nullptr) {
+      // Output the arguments (for example purposes, we'll just print them)
+      for (int i = 0; i < argc - 1; ++i) {
+        if (std::wstring(argv[i]) == L"-ccm" && i + 1 < argc) {
+          // Found "-ccm", so take the next argument as the value
+          argValue = argv[i + 1];
+          break;
+        }
+      }
+
+      if (!argValue.empty()) {
+        configFile = ConvertWStringToString(argValue);
+      }
+
+      // Clean up
+      LocalFree(argv);
+    }
+#endif
+
+    // Second check here is because on windows, it may still be
+    // unset at this point.  On the mac, we do not currently
+    // support multiple configuration files
+    if (configFile.empty()) {
+      configFile = CONFIG_FILE_DEFAULT;
+    }
+  }
+
+  return configFile;
+}
+
 void Config::Load()
 {
-  spdlog::info("Loading Config");
+  spdlog::info("=-=-=-==-=-=-=-=-=-=-=-=-=-=");
+  spdlog::info("Loading Config :: {}", Config::Filename());
+  spdlog::info("=-=-=-==-=-=-=-=-=-=-=-=-=-=");
 
   toml::table config;
   toml::table parsed;
   bool        write_config = false;
   try {
-    config       = std::move(toml::parse_file(make_config_path(CONFIG_FILE_DEFAULT)));
+    config       = std::move(toml::parse_file(make_config_path(Config::Filename())));
     write_config = true;
   } catch (const toml::parse_error& e) {
     spdlog::warn("Failed to load config file, falling back to default settings: {}", e.description());
@@ -540,10 +608,10 @@ void Config::Load()
 
   if (!std::filesystem::exists(make_config_path(CONFIG_FILE_RUNTIME))) {
     message.str("");
-    message << "Creating " << CONFIG_FILE_DEFAULT << " (default config file)";
+    message << "Creating " << Config::Filename() << " (default config file)";
     spdlog::warn(message.str());
 
-    Config::Save(config, CONFIG_FILE_DEFAULT, false);
+    Config::Save(config, Config::Filename(), false);
   }
 
   message.str("");

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <vector>
 
 #include <toml++/toml.h>
@@ -77,10 +78,9 @@ public:
   bool always_skip_reveal_sequence;
   bool stay_in_bundle_after_summary;
 
+  std::map<std::string, std::string> sync_targets;
   std::string sync_proxy;
-  std::string sync_url;
   std::string sync_file;
-  std::string sync_token;
   bool        sync_logging;
   bool        sync_resources;
   bool        sync_battlelogs;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -18,6 +18,8 @@ public:
   static float   GetDPI();
   static float   RefreshDPI();
 
+  static std::string_view Filename();
+
   static void Save(toml::table config, std::string_view filename, bool apply_warning = true);
   void        Load();
   void        AdjustUiScale(bool scaleUp);

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -614,10 +614,13 @@ void HandleEntityGroup(EntityGroup* entity_group)
         for (const auto& resource : result["resources"].get<json::object_t>()) {
           auto id     = std::stoll(resource.first);
           auto amount = resource.second["current_amount"].get<int64_t>();
-          if (amount == 0) {
-            continue;
-          }
-          if (resource_states[id] != amount) {
+
+          const auto prevResourceAmountIter = resource_states.find(id);
+          const auto hadResource = (prevResourceAmountIter != resource_states.end() && prevResourceAmountIter->second != 0);
+          const auto amountChanged = amount > 0 && (prevResourceAmountIter == resource_states.end() || prevResourceAmountIter->second != amount);
+          const auto resourceDepleted = hadResource && amount == 0;
+
+          if (resourceDepleted || amountChanged) {
             resource_states[id] = amount;
             resource_array.push_back({{"type", "resource"}, {"rid", id}, {"amount", amount}});
           }

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -534,7 +534,7 @@ void HandleEntityGroup(EntityGroup* entity_group)
         if (officer_states[officer.id()] != RankLevelState{officer.rankindex(), officer.level()}) {
           officer_states[officer.id()] = RankLevelState{officer.rankindex(), officer.level()};
           officers_array.push_back(
-              {{"type", "officer"}, {"oid", officer.id()}, {"rank", officer.rankindex()}, {"level", officer.level()}});
+              {{"type", "officer"}, {"oid", officer.id()}, {"rank", officer.rankindex()}, {"level", officer.level()}, {"shard_count", officer.shardcount()}});
         }
       }
       if (Config::Get().sync_officer) {
@@ -548,7 +548,7 @@ void HandleEntityGroup(EntityGroup* entity_group)
       for (const auto& ft : response.forbiddentechs()) {
         if (ft_states[ft.id()] != RankLevelState{ft.tier(), ft.level()}) {
           ft_states[ft.id()] = RankLevelState{ft.tier(), ft.level()};
-          ft_array.push_back({{"type", "ft"}, {"fid", ft.id()}, {"tier", ft.tier()}, {"level", ft.level()}});
+          ft_array.push_back({{"type", "ft"}, {"fid", ft.id()}, {"tier", ft.tier()}, {"level", ft.level()}, {"shard_count", ft.shardcount()}});
         }
       }
       if (Config::Get().sync_tech) {

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -183,7 +183,7 @@ static const std::string PRIME_API_KEY      = "meh";
 static void send_data(std::wstring post_data)
 {
   static auto loggedUrl = false;
-  if (Config::Get().sync_url.empty()) {
+  if (Config::Get().sync_targets.empty()) {
     if (!loggedUrl) {
       loggedUrl = true;
       sync_log_warn(CURL_TYPE_UPLOAD, "No url found, will not attempt to send");
@@ -191,36 +191,37 @@ static void send_data(std::wstring post_data)
     return;
   }
 
-  std::wstring httpResponseBody;
+  for (const auto& sync_target : Config::Get().sync_targets) {
+    const auto& url = sync_target.first;
+    const auto& token = sync_target.second;
 
-  auto         url = Config::Get().sync_url;
-  CURL*        httpClient = sync_init(CURL_TYPE_UPLOAD, url);
+    CURL*        httpClient = sync_init(CURL_TYPE_UPLOAD, url);
 
-  struct curl_slist* list = NULL;
+    struct curl_slist* list = NULL;
 
-  list = sync_slist_append(CURL_TYPE_UPLOAD, list, "Content-Type", "application/json");
+    list = sync_slist_append(CURL_TYPE_UPLOAD, list, "Content-Type", "application/json");
 
-  auto token = Config::Get().sync_token;
-  if (!token.empty()) {
-    list = sync_slist_append(CURL_TYPE_UPLOAD, list, "stfc-sync-token", token.c_str(), true);
-  }
+    if (!token.empty()) {
+      list = sync_slist_append(CURL_TYPE_UPLOAD, list, "stfc-sync-token", token, true);
+    }
 
-  if (list) {
-    process_curl_response(CURL_TYPE_UPLOAD, "set headers", curl_easy_setopt(httpClient, CURLOPT_HTTPHEADER, list));
-  }
+    if (list) {
+      process_curl_response(CURL_TYPE_UPLOAD, "set headers", curl_easy_setopt(httpClient, CURLOPT_HTTPHEADER, list));
+    }
 
-  auto post_data_str = to_string(post_data);
-  process_curl_response(CURL_TYPE_UPLOAD, "set data",
-                        curl_easy_setopt(httpClient, CURLOPT_POSTFIELDS, post_data_str.c_str()));
+    auto post_data_str = to_string(post_data);
+    process_curl_response(CURL_TYPE_UPLOAD, "set data",
+                          curl_easy_setopt(httpClient, CURLOPT_POSTFIELDS, post_data_str.c_str()));
 
-  process_curl_response(CURL_TYPE_UPLOAD, "send data", curl_easy_perform(httpClient), true);
+    process_curl_response(CURL_TYPE_UPLOAD, "send data", curl_easy_perform(httpClient), true);
 
-  long http_code = 0;
-  process_curl_response(CURL_TYPE_UPLOAD, "get response code",
-                        curl_easy_getinfo(httpClient, CURLINFO_RESPONSE_CODE, &http_code));
+    long http_code = 0;
+    process_curl_response(CURL_TYPE_UPLOAD, "get response code",
+                          curl_easy_getinfo(httpClient, CURLINFO_RESPONSE_CODE, &http_code));
 
-  if (http_code != 200) {
-    process_curl_response(CURL_TYPE_UPLOAD, "communicate with server", http_code, true);
+    if (http_code != 200) {
+      process_curl_response(CURL_TYPE_UPLOAD, "communicate with server", http_code, true);
+    }
   }
 }
 
@@ -235,7 +236,7 @@ static std::wstring get_data_data(std::wstring session, std::wstring url, std::w
 {
   static auto loggedUrl = false;
 
-  if (Config::Get().sync_url.empty() && Config::Get().sync_file.empty()) {
+  if (Config::Get().sync_targets.empty() && Config::Get().sync_file.empty()) {
     if (!loggedUrl) {
       loggedUrl = true;
       sync_log_warn(CURL_TYPE_DOWNLOAD, "Not retreiving data, no sync url or file");

--- a/win-proxy-dll/xmake.lua
+++ b/win-proxy-dll/xmake.lua
@@ -9,6 +9,7 @@ do
     set_exceptions("cxx")
     if is_plat("windows") then
         add_cxflags("/bigobj")
+        add_links("Shell32.lib")
     end
     set_policy("build.optimization.lto", true)
     add_links("User32.lib", "Ole32.lib", "OleAut32.lib")


### PR DESCRIPTION
Add support for multiple sync targets. Legacy options `sync_url` and `sync_token` will be converted to `[sync.targets.default]`.

```YAML
[sync]

    [sync.targets.local]
    token = 'foo'
    url = 'http://localhost/sync/ingress/'

    [sync.targets.spocksclub]
    token = 'bar'
    url = 'https://spocks.club/sync/ingress/'
```