### PR TITLE
Write log file to OS-standard location instead of game directory

### DIFF
--- a/mods/src/file.cc
+++ b/mods/src/file.cc
@@ -192,7 +192,25 @@ void File::Init()
     if (File::override) {
       cacheNameLog = configPath.replace_extension(FILE_EXT_LOG).string();
     } else {
-      cacheNameLog = std::string(FILE_DEF_LOG);
+#if !_WIN32
+      const std::filesystem::path libraryPath =
+          fm::FolderManager::pathForDirectory(fm::NSLibraryDirectory, fm::NSUserDomainMask);
+      const auto log_dir = libraryPath / "Logs" / "com.stfcmod.startrekpatch";
+      std::error_code ec;
+      std::filesystem::create_directories(log_dir, ec);
+      cacheNameLog = (log_dir / FILE_DEF_LOG).string();
+#else
+      PWSTR localAppData = nullptr;
+      if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppData))) {
+        std::filesystem::path log_dir = std::filesystem::path(localAppData) / "stfcmod" / "Logs";
+        CoTaskMemFree(localAppData);
+        std::error_code ec;
+        std::filesystem::create_directories(log_dir, ec);
+        cacheNameLog = (log_dir / FILE_DEF_LOG).string();
+      } else {
+        cacheNameLog = std::string(FILE_DEF_LOG);
+      }
+#endif
     }
 
     /*******************************

--- a/mods/src/file.h
+++ b/mods/src/file.h
@@ -18,6 +18,7 @@
 #if !_WIN32
 #include "folder_manager.h"
 #else
+#include <ShlObj.h>
 #include <shellapi.h>
 #include <windows.h>
 #endif


### PR DESCRIPTION
## Summary

The log file was written relative to the game's working directory, making it hard to find when debugging user-reported issues. This PR writes the log to OS-standard locations:

- **macOS:** `~/Library/Logs/com.stfcmod.startrekpatch/community_patch.log`
- **Windows:** `%LOCALAPPDATA%\stfcmod\Logs\community_patch.log`

The log directory is created automatically on startup. The `-ccm` command line override continues to work as before.

## Changes

- `file.cc`: Platform-specific log path calculation in the default (non-override) case
- `file.h`: Add `ShlObj.h` include for `SHGetKnownFolderPath` on Windows

## Test plan

- [x] `xmake build` succeeds on macOS (arm64)
- [x] Log file appears at `~/Library/Logs/com.stfcmod.startrekpatch/community_patch.log`
- [x] Log directory is created if it does not exist
- [ ] Windows build and log path verification (not yet tested)