### PR TITLE
Update to latest GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,10 @@ concurrency:
 
 jobs:
   build-win:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: "recursive"
 
@@ -37,17 +37,17 @@ jobs:
         run: mv build/windows/x64/release/stfc-community-patch.dll version.dll
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stfc-community-mod
           path: version.dll
           if-no-files-found: error
 
   build-mac:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: "recursive"
 
@@ -59,13 +59,13 @@ jobs:
           package-cache-key: ${{ hashFiles('**/xmake.lua', '!win-*/xmake.lua') }}
 
       - name: Configure (arm64)
-        run: xmake f -p macosx -a "arm64" -m release -y --target_minver=13.5
+        run: xmake f -p macosx -a "arm64" -m release -y --target_minver=15.4
 
       - name: Build (arm64)
         run: xmake -y
 
       - name: Configure (x86)
-        run: xmake f -p macosx -a "x86_64" -m release -y --target_minver=13.5
+        run: xmake f -p macosx -a "x86_64" -m release -y --target_minver=15.4
 
       - name: Build (x86)
         run: xmake -y
@@ -89,7 +89,7 @@ jobs:
         run: create-dmg --filesystem APFS --format ULFO --volname "STFC Community Mod Installer" --volicon assets/launcher.icns --background assets/mac_installer_background.png --window-pos 200 120 --window-size 800 400 --icon-size 100 --icon "STFC Community Mod.app" 200 190 --app-drop-link 600 185 stfc-community-mod-installer.dmg build/macosx/arm64/release/
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stfc-community-mod-installer
           path: stfc-community-mod-installer.dmg

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # ✅ Step 1 — Check if Build succeeded for this same commit
       - name: Check latest Build success
@@ -38,7 +38,7 @@ jobs:
 
       # ✅ Step 2 — Download the Build artifacts
       - name: Download artifact from Build workflow
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v18
         with:
           run_id: ${{ steps.check_build.outputs.build_run_id }}
 


### PR DESCRIPTION
Also bumps the macOS target to 15.4 as that gets you 95% market share and we have no ability to fix problems on 13/14 anyway.