### PR TITLE
Max sure setDepth hook is only registered on Windows

### DIFF
--- a/mods/src/patches/parts/zoom.cc
+++ b/mods/src/patches/parts/zoom.cc
@@ -175,12 +175,14 @@ void InstallZoomHooks()
       SPUD_STATIC_DETOUR(ptr_update, NavigationZoom_Update_Hook);
     }
 
+#if _WIN32
     auto ptr_set_depth = screen_manager_helper.GetMethod("SetDepth");
     if (ptr_set_depth == nullptr) {
       ErrorMsg::MissingMethod("NavigationZoom", "SetDepth");
     } else {
       SPUD_STATIC_DETOUR(ptr_set_depth, NavigationZoom_SetDepth_Hook);
     }
+#endif
 
     auto ptr_set_view_parameters = screen_manager_helper.GetMethod("SetViewParameters");
     if (ptr_set_view_parameters == nullptr) {


### PR DESCRIPTION
This hook causes macOS to hang on system map.