### PR TITLE
feat: add double-tap Escape to exit when disable_escape_exit is enabled

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -310,9 +310,13 @@ always_skip_reveal_sequence = true
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
-# When disable_escape_exit is true, allow double-tap Escape to still trigger
-# the exit prompt. Set the maximum time in milliseconds between presses.
-# Set to 0 to disable double-tap (Escape is fully blocked).
+# When disable_escape_exit is true, this lets you double-tap Escape to still
+# get the exit prompt. The value is the maximum gap in milliseconds between
+# two Escape presses to count as a double-tap.
+#
+#   0   = double-tap disabled, Escape is fully blocked (default)
+#   500 = press Escape twice within half a second to trigger the exit prompt
+#
 # Has no effect when disable_escape_exit is false.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -310,6 +310,12 @@ always_skip_reveal_sequence = true
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
+# When disable_escape_exit is true, allow double-tap Escape to still trigger
+# the exit prompt. Set the maximum time in milliseconds between presses.
+# Set to 0 to disable double-tap (Escape is fully blocked).
+# Has no effect when disable_escape_exit is false.
+escape_exit_timer = 0
+
 # ⚠️ EXPERIMENTAL: Prevent the first popup advert from appearing
 disable_first_popup = false
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -562,6 +562,7 @@ void Config::Load()
   spdlog::debug("");
 
   this->disable_escape_exit    = get_config_or_default(config, parsed, "ui", "disable_escape_exit", DCU::disable_escape_exit, write_config);
+  this->escape_exit_timer      = get_config_or_default(config, parsed, "ui", "escape_exit_timer", DCU::escape_exit_timer, write_config);
   this->disable_preview_locate = get_config_or_default(config, parsed, "ui", "disable_preview_locate", DCU::disable_preview_locate, write_config);
   this->disable_preview_recall = get_config_or_default(config, parsed, "ui", "disable_preview_recall", DCU::disable_preview_recall, write_config);
   this->disable_first_popup    = get_config_or_default(config, parsed, "ui", "disable_first_popup", DCU::disable_first_popup, write_config);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -167,6 +167,7 @@ public:
   bool disable_preview_locate;
   bool disable_preview_recall;
   bool disable_escape_exit;
+  int  escape_exit_timer;
   bool disable_galaxy_chat;
   bool disable_veil_chat;
   bool disable_first_popup;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -188,6 +188,7 @@ namespace UI
   constexpr bool        always_skip_reveal_sequence = true;
   constexpr bool        auto_confirm_discovery      = true;
   constexpr bool        disable_escape_exit         = true;
+  constexpr auto        escape_exit_timer           = 0;
   constexpr bool        disable_first_popup         = false;
   constexpr bool        disable_galaxy_chat         = false;
   constexpr bool        disable_move_keys           = false;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -188,6 +188,8 @@ namespace UI
   constexpr bool        always_skip_reveal_sequence = true;
   constexpr bool        auto_confirm_discovery      = true;
   constexpr bool        disable_escape_exit         = true;
+  // Max ms between two Escape presses to count as a double-tap.
+  // 0 = disabled (Escape fully blocked). 500 = half-second window.
   constexpr auto        escape_exit_timer           = 0;
   constexpr bool        disable_first_popup         = false;
   constexpr bool        disable_galaxy_chat         = false;

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -426,7 +426,14 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
   }
 
   if (config->disable_escape_exit && Key::Pressed(KeyCode::Escape)) {
-    return;
+    static std::chrono::time_point<std::chrono::steady_clock> escape_clock = {};
+    std::chrono::time_point<std::chrono::steady_clock>        escape_now   = std::chrono::steady_clock::now();
+    std::chrono::milliseconds escape_diff = std::chrono::duration_cast<std::chrono::milliseconds>(escape_now - escape_clock);
+    escape_clock                          = escape_now;
+    if (config->escape_exit_timer <= 0 || escape_diff > std::chrono::milliseconds(config->escape_exit_timer)) {
+      return;
+    }
+    // Double-tap detected — fall through to original() to trigger exit
   }
 
   // config->Load();

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -426,6 +426,8 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
   }
 
   if (config->disable_escape_exit && Key::Pressed(KeyCode::Escape)) {
+    // Double-tap exit: if two Escape presses occur within escape_exit_timer ms,
+    // fall through to the original handler to show the exit prompt.
     static std::chrono::time_point<std::chrono::steady_clock> escape_clock = {};
     std::chrono::time_point<std::chrono::steady_clock>        escape_now   = std::chrono::steady_clock::now();
     std::chrono::milliseconds escape_diff = std::chrono::duration_cast<std::chrono::milliseconds>(escape_now - escape_clock);


### PR DESCRIPTION
## Summary

Adds a double-tap Escape mechanism to exit the game even when `disable_escape_exit` is enabled.

Currently, when `disable_escape_exit = true`, all Escape key presses are unconditionally swallowed. This means users have no keyboard-only way to trigger the exit prompt — they must use the F10 hard kill (which calls `TerminateProcess` with no cleanup).

This PR adds a configurable double-tap window: press Escape twice within `escape_exit_timer` milliseconds to fall through to the original handler and trigger the native exit dialog.

## New Config Option

```toml
[ui]
# When disable_escape_exit is true, allow double-tap Escape to still trigger
# the exit prompt. Set the maximum time in milliseconds between presses.
# Set to 0 to disable double-tap (Escape is fully blocked).
# Has no effect when disable_escape_exit is false.
escape_exit_timer = 0
```

## Implementation

Uses the same `std::chrono::steady_clock` double-tap pattern already established for ship selection (`select_clock` in `hotkeys.cc` line 75). A static `escape_clock` tracks the last Escape press time — first press is swallowed, second press within the timer window falls through to `original(_this)`.

## Files Changed

| File | Change |
|------|--------|
| `mods/src/patches/parts/hotkeys.cc` | Double-tap timer logic in the `disable_escape_exit` guard |
| `mods/src/config.h` | Added `escape_exit_timer` field |
| `mods/src/config.cc` | Load `escape_exit_timer` from `[ui]` section |
| `mods/src/defaultconfig.h` | Default value: `0` (preserves existing behavior) |
| `example_community_patch_settings.toml` | Documented the new option |

## Behavior

| `disable_escape_exit` | `escape_exit_timer` | Effect |
|---|---|---|
| `false` | *(ignored)* | Escape works normally (game default) |
| `true` | `0` (default) | Escape fully blocked (existing behavior preserved) |
| `true` | `500` | Double-tap Escape within 500ms to exit |

## Testing

Built and tested on Windows with `releasedbg` mode. Confirmed:
- Single Escape press is swallowed when `disable_escape_exit = true`
- Double-tap within 500ms triggers the exit prompt
- Setting `escape_exit_timer = 0` fully blocks Escape (backward compatible)
- No impact on Escape behavior when `disable_escape_exit = false`