### PR TITLE
fix: legacy sync url/token now inherits data sync options (#106)

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -610,11 +610,17 @@ void Config::Load()
     spdlog::warn("Deprecation Warning: Legacy config options 'sync_url' and 'sync_token' have been moved to "
                  "[sync.targets.<name>] sections and may be removed in a future version.");
 
-    SyncTargetConfig converted_target{.url = sync_url.value(), .token = sync_token.value()};
+    SyncTargetConfig converted_target;
+    static_cast<SyncConfig&>(converted_target) = sync_defaults;
+    converted_target.url   = sync_url.value();
+    converted_target.token = sync_token.value();
 
     if (this->sync_targets.emplace("default", converted_target).second) {
-      parsed["sync"]["targets"].as_table()->emplace<toml::table>(
-          "default", toml::table{{"url", sync_url.value()}, {"token", sync_token.value()}});
+      toml::table default_target{{"url", sync_url.value()}, {"token", sync_token.value()}, {"proxy", converted_target.proxy}};
+      for (const auto& opt : SyncOptions) {
+        default_target.insert(opt.option_str, converted_target.*opt.option);
+      }
+      parsed["sync"]["targets"].as_table()->emplace<toml::table>("default", default_target);
       spdlog::info(
           "Legacy config options 'sync_url' and 'sync_token' were converted to sync.targets.default url: {}, token: {}",
           sync_url.value(), sync_token.value());


### PR DESCRIPTION
## Summary

Fixes #106 — when users configure sync using the legacy `[sync]` section with `url` and `token` keys, the converted `sync.targets.default` target now correctly inherits all data sync options (battlelogs, buffs, buildings, inventory, jobs, missions, officers, research, resources, ships, slots, tech, traits).

## Blocked by

- #130 — duplicate hook fix for `ProcessResultInternal` (prevents ~20% crash on load)

## Problem

Legacy config like:
```toml
[sync]
url = "https://spocks.club/sync/ingress/"
token = "abc123"
battlelogs = true
buffs = true
# ... etc
```

Was converted to `sync.targets.default` with only `url` and `token` set — all the boolean options defaulted to `false`, so no data was actually synced.

## Changes

### `mods/src/config.cc`
- Legacy conversion now copies the parsed `sync_defaults` (which contains all the user's boolean options) into the converted target before setting `url` and `token`
- All sync options are also written to the TOML vars file under `[sync.targets.default]` for visibility

### `mods/src/str_utils.h`
- Added null guards to `to_wstring(Il2CppString*)` and `to_string(Il2CppString*)` — the game engine can pass null pointers through hooked functions, causing access violations

## How to verify

1. Set up a legacy `[sync]` config with `url`, `token`, and data flags like `battlelogs = true`
2. Launch the game — check `community_patch_runtime.vars` for a `[sync.targets.default]` section with all flags present
3. With `logging = true`, confirm data uploads succeed (200 OK)