### PR TITLE
fix: skip duplicate hook when IL2CPP aliases ProcessResultInternal

### DIFF
--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -2041,6 +2041,8 @@ void InstallSyncPatches()
 {
   load_previously_sent_logs();
 
+  void* process_result_internal_target = nullptr;
+
   if (auto game_server_model_registry =
           il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Core", "GameServerModelRegistry");
       !game_server_model_registry.isValidHelper()) {
@@ -2051,6 +2053,7 @@ void InstallSyncPatches()
       ErrorMsg::MissingMethod("GameServerModelRegistry", "ProcessResultInterval");
     } else {
       SPUD_STATIC_DETOUR(ptr, GameServerModelRegistry_ProcessResultInternal);
+      process_result_internal_target = ptr;
     }
 
     ptr = game_server_model_registry.GetMethod("HandleBinaryObjects");
@@ -2068,6 +2071,8 @@ void InstallSyncPatches()
   } else {
     if (const auto ptr = platform_model_registry.GetMethod("ProcessResultInternal"); ptr == nullptr) {
       ErrorMsg::MissingMethod("PlatformModelRegistry", "ProcessResultInterval");
+    } else if (ptr == process_result_internal_target) {
+      spdlog::info("PlatformModelRegistry::ProcessResultInternal shares address with GameServerModelRegistry — already hooked");
     } else {
       SPUD_STATIC_DETOUR(ptr, GameServerModelRegistry_ProcessResultInternal);
     }


### PR DESCRIPTION
**Problem**

`PlatformModelRegistry::ProcessResultInternal` and `GameServerModelRegistry::ProcessResultInternal` can resolve to the same IL2CPP method pointer. When both are hooked with `SPUD_STATIC_DETOUR`, the second detour overwrites the first — leaving `GameServerModelRegistry`'s hook broken and causing crashes or silent data loss.

**Fix**

Track the pointer used for `GameServerModelRegistry::ProcessResultInternal`. Before hooking `PlatformModelRegistry::ProcessResultInternal`, compare its pointer — if they match, log that the method is already hooked and skip the duplicate detour.

**Changes**
- `mods/src/patches/parts/sync.cc`: 5 lines added — pointer tracking + equality check + skip log

**Rationale**
- If both methods resolve to the same address, a single `SPUD_STATIC_DETOUR` already intercepts calls from both registries — a second detour on the same address seems to corrupt the first.