### PR TITLE
feat: notification framework with config-driven OS toast delivery

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -324,6 +324,12 @@ disable_toast_banners = false
 
 disabled_banner_types = ""
 
+# System notifications for in-game events. Comma-separated list of toast types
+# to deliver as OS-level notifications (Windows toast). Uses the same type names
+# as disabled_banner_types. Empty string = no notifications.
+# Example: "Victory, Defeat, IncomingAttack, StationBattle"
+notify_banner_types = ""
+
 # Subgroup: Chat
 # --------------
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -683,6 +683,29 @@ void Config::Load()
 
   parsed["ui"].as_table()->insert_or_assign("disabled_banner_types", bannerString);
 
+  // Parse notify_banner_types using the same bannerTypes lookup table
+  auto notify_banner_types_str =
+      get_config_or_default<std::string>(config, parsed, "ui", "notify_banner_types", DCU::notify_banner_types, write_log);
+
+  std::vector<std::string> notify_types = StrSplit(notify_banner_types_str, ',');
+  std::string              notifyString;
+
+  for (const auto& [key, value] : bannerTypes) {
+    auto upper_key = AsciiStrToUpper(key);
+    for (const std::string_view _type : notify_types) {
+      auto stripped_type = StripLeadingAsciiWhitespace(_type);
+      auto upper_type    = AsciiStrToUpper(stripped_type);
+      if (upper_key == upper_type) {
+        this->notify_banner_types.emplace_back(value);
+        if (!notifyString.empty()) notifyString.append(", ");
+        notifyString.append(key);
+      }
+    }
+  }
+
+  spdlog::debug("Final notify banner types: {}", notifyString);
+  parsed["ui"].as_table()->insert_or_assign("notify_banner_types", notifyString);
+
   spdlog::debug("");
 
   //if (this->enable_experimental) {

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -160,6 +160,7 @@ public:
 
   bool             borderless_fullscreen;
   std::vector<int> disabled_banner_types;
+  std::vector<int> notify_banner_types;
 
   int  extend_donation_max;
   bool extend_donation_slider;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -196,6 +196,7 @@ namespace UI
   constexpr bool        disable_toast_banners       = false;
   constexpr bool        disable_veil_chat           = false;
   constexpr const char* disabled_banner_types       = "";
+  constexpr const char* notify_banner_types         = "";
   constexpr auto        extend_donation_max         = 80;
   constexpr bool        extend_donation_slider      = true;
   constexpr bool        show_armada_cargo           = true;

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,0 +1,205 @@
+#include "patches/notification_service.h"
+
+#include "config.h"
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/LanguageManager.h>
+#include <prime/Toast.h>
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#include <winrt/Windows.Data.Xml.Dom.h>
+#include <winrt/Windows.UI.Notifications.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// IL2CPP method cache
+// ---------------------------------------------------------------------------
+static const MethodInfo* s_localize_ltc = nullptr;
+
+// ---------------------------------------------------------------------------
+// Toast state → human-readable title
+// ---------------------------------------------------------------------------
+static const char* toast_state_title(int state)
+{
+  switch (state) {
+    case Victory:                   return "Victory!";
+    case Defeat:                    return "Defeat";
+    case PartialVictory:            return "Partial Victory";
+    case StationVictory:            return "Station Victory!";
+    case StationDefeat:             return "Station Defeat";
+    case StationBattle:             return "Station Under Attack!";
+    case IncomingAttack:            return "Incoming Attack!";
+    case IncomingAttackFaction:     return "Incoming Faction Attack!";
+    case FleetBattle:               return "Fleet Battle";
+    case ArmadaBattleWon:           return "Armada Victory!";
+    case ArmadaBattleLost:          return "Armada Defeated";
+    case ArmadaCreated:             return "Armada Created";
+    case ArmadaCanceled:            return "Armada Canceled";
+    case ArmadaIncomingAttack:      return "Armada Under Attack!";
+    case AssaultVictory:            return "Assault Victory!";
+    case AssaultDefeat:             return "Assault Defeat";
+    case Tournament:                return "Event Progress";
+    case ChainedEventScored:        return "Event Progress";
+    case Achievement:               return "Achievement";
+    case ChallengeComplete:         return "Challenge Complete";
+    case ChallengeFailed:           return "Challenge Failed";
+    case TakeoverVictory:           return "Takeover Victory!";
+    case TakeoverDefeat:            return "Takeover Defeat";
+    case TreasuryProgress:          return "Treasury Progress";
+    case TreasuryFull:              return "Treasury Full";
+    case WarchestProgress:          return "Warchest Progress";
+    case WarchestFull:              return "Warchest Full";
+    case FactionLevelUp:            return "Faction Level Up";
+    case FactionLevelDown:          return "Faction Level Down";
+    case FactionDiscovered:         return "Faction Discovered";
+    case FactionWarning:            return "Faction Warning";
+    case DiplomacyUpdated:          return "Diplomacy Updated";
+    case StrikeHit:                 return "Strike Hit";
+    case StrikeDefeat:              return "Strike Defeat";
+    case SurgeWarmUpEnded:          return "Surge Started";
+    case SurgeHostileGroupDefeated: return "Surge Hostiles Defeated";
+    case SurgeTimeLeft:             return "Surge Time Warning";
+    case ArenaTimeLeft:             return "Arena Time Warning";
+    case FleetPresetApplied:        return "Fleet Preset Applied";
+    default:                        return nullptr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform notification delivery
+// ---------------------------------------------------------------------------
+#if _WIN32
+static void show_system_notification(const char* title, const char* body)
+{
+  try {
+    using namespace winrt::Windows::UI::Notifications;
+    using namespace winrt::Windows::Data::Xml::Dom;
+
+    auto xml   = ToastNotificationManager::GetTemplateContent(ToastTemplateType::ToastText02);
+    auto nodes = xml.GetElementsByTagName(L"text");
+    nodes.Item(0).InnerText(winrt::to_hstring(title));
+    nodes.Item(1).InnerText(winrt::to_hstring(body));
+
+    auto notification = ToastNotification(xml);
+    auto notifier     = ToastNotificationManager::CreateToastNotifier(L"Star Trek Fleet Command");
+    notifier.Show(notification);
+  } catch (const winrt::hresult_error& e) {
+    spdlog::warn("[Notify] WinRT notification failed: {}", winrt::to_string(e.message()));
+  } catch (...) {
+    spdlog::warn("[Notify] WinRT notification failed (unknown error)");
+  }
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// Resolve basic localized text from a Toast's TextLocaleTextContext
+// ---------------------------------------------------------------------------
+static std::string resolve_toast_text(Toast* toast)
+{
+  if (!s_localize_ltc) return {};
+
+  auto* ltc = toast->get_TextLocaleTextContext();
+  if (!ltc) return {};
+
+  auto* langMgr = LanguageManager::Instance();
+  if (!langMgr) return {};
+
+  Il2CppString*  resolved = nullptr;
+  void*          params[2] = { &resolved, ltc };
+  Il2CppException* exc = nullptr;
+  il2cpp_runtime_invoke(s_localize_ltc, langMgr, params, &exc);
+
+  if (exc || !resolved) return {};
+  return to_string(resolved);
+}
+
+// ---------------------------------------------------------------------------
+// Strip Unity rich text tags (e.g. <color=#FF0000>, <b>, </size>)
+// ---------------------------------------------------------------------------
+static std::string strip_unity_rich_text(const std::string& s)
+{
+  std::string result;
+  result.reserve(s.size());
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '<') {
+      auto end = s.find('>', i);
+      if (end != std::string::npos) { i = end + 1; continue; }
+    }
+    result += s[i++];
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void notification_init()
+{
+  // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
+  // 2-parameter overload that takes an LTC and returns a localized string.
+  auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
+  if (lm_helper.isValidHelper()) {
+    auto* cls = lm_helper.get_cls();
+    if (cls) {
+      void* iter = nullptr;
+      while (auto* method = il2cpp_class_get_methods(cls, &iter)) {
+        auto name = std::string_view(il2cpp_method_get_name(method));
+        auto pc   = il2cpp_method_get_param_count(method);
+        if (name == "Localize" && pc == 2) {
+          s_localize_ltc = method;
+          spdlog::info("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
+          break;
+        }
+      }
+    }
+  }
+
+  if (!s_localize_ltc) {
+    spdlog::warn("[Notify] Could not resolve LanguageManager::Localize — notifications will show titles only");
+  }
+
+#if _WIN32
+  try { winrt::init_apartment(); } catch (...) {}
+  spdlog::info("[Notify] Windows notification service initialized");
+#else
+  spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+}
+
+void notification_handle_toast(Toast* toast)
+{
+#if !_WIN32
+  return; // No notification delivery on non-Windows platforms yet
+#else
+  auto state = toast->get_State();
+
+  // Check if this toast type is in the user's notify list
+  const auto& notify_types = Config::Get().notify_banner_types;
+  if (std::ranges::find(notify_types, state) == notify_types.end()) {
+    return;
+  }
+
+  auto* title = toast_state_title(state);
+  if (!title) {
+    spdlog::debug("[Notify] No title mapping for toast state {}, skipping", state);
+    return;
+  }
+
+  auto body = strip_unity_rich_text(resolve_toast_text(toast));
+  if (body.empty()) {
+    body = "(no details available)";
+  }
+
+  spdlog::info("[Notify] {} — {}", title, body);
+  show_system_notification(title, body.c_str());
+#endif
+}

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -1,0 +1,10 @@
+#pragma once
+
+struct Toast;
+
+// Initialize the notification service (resolve IL2CPP methods, init platform).
+// Call once during InstallToastBannerHooks().
+void notification_init();
+
+// Called from toast hooks — checks config, formats, and delivers notification.
+void notification_handle_toast(Toast* toast);

--- a/mods/src/patches/parts/disable_banners.cc
+++ b/mods/src/patches/parts/disable_banners.cc
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "errormsg.h"
+#include "patches/notification_service.h"
 
 #include <il2cpp/il2cpp_helper.h>
 #include <prime/Toast.h>
@@ -11,6 +12,8 @@ struct ToastObserver {
 
 void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast *toast)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -21,6 +24,8 @@ void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast 
 
 void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_this, Toast *toast, uintptr_t cmpAction)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -31,6 +36,8 @@ void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_thi
 
 void InstallToastBannerHooks()
 {
+  notification_init();
+
   if (auto helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "ToastObserver");
       !helper.isValidHelper()) {
     ErrorMsg::MissingHelper("HUD", "ToastObserver");

--- a/mods/src/prime/Toast.h
+++ b/mods/src/prime/Toast.h
@@ -50,6 +50,16 @@ enum ToastState {
 
 struct Toast {
 public:
+  void* get_TextLocaleTextContext()
+  {
+    return *reinterpret_cast<void**>(reinterpret_cast<char*>(this) + 0x20);
+  }
+
+  Il2CppObject* get_Data()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x38);
+  }
+
   int get_State()
   {
     static auto prop = get_class_helper().GetProperty("State");


### PR DESCRIPTION
## Summary

Adds a reusable notification framework that delivers Windows OS toast notifications for configurable in-game banner types. This is the foundation layer — individual event parsers (battle results, event progress, etc.) will be added in follow-up PRs.

## What Changed

### New Files
- **`mods/src/patches/notification_service.h/.cc`** — Public API (`notification_init()`, `notification_handle_toast(Toast*)`) with:
  - IL2CPP reflection to resolve `LanguageManager::Localize(out, LocaleTextContext)` at runtime
  - `toast_state_title()` mapping all 44 ToastState enum values to human-readable titles
  - `resolve_toast_text()` for generic localized text extraction from any toast
  - `strip_unity_rich_text()` to clean `<color>`, `<b>`, etc. tags for plain-text display
  - WinRT toast delivery via `Windows.UI.Notifications` (Windows only, compile-time no-op elsewhere)

### Modified Files
- **`mods/src/config.h/.cc`** — Added `notify_banner_types` vector (same pattern as `disabled_banner_types`)
- **`mods/src/defaultconfig.h`** — Added `notify_banner_types = ""` default
- **`mods/src/patches/parts/disable_banners.cc`** — Hooks call `notification_handle_toast()` in both `EnqueueToast` and `EnqueueOrCombineToast` (before the disable filter), `notification_init()` at hook install time
- **`mods/src/prime/Toast.h`** — Added `get_TextLocaleTextContext()` and `get_Data()` accessors
- **`example_community_patch_settings.toml`** — Documented `notify_banner_types` config

## Design Decisions
- **Zero dependencies**: Uses WinRT (Windows SDK already in build) instead of third-party toast libraries
- **Config-driven**: `notify_banner_types` uses the same banner type names as `disabled_banner_types` — users configure which events trigger OS notifications
- **Platform guards**: Hard `#if _WIN32` / `#if !_WIN32 return;` — non-Windows is a compile-time no-op
- **Parser-ready**: `notification_handle_toast` is designed for follow-up parsers to provide richer notification bodies (e.g., battle results with player/ship names)

## BLOCKED BY
- #130 (fix/duplicate-hook-target — ProcessResultInternal guard needed to prevent 20% load crash)