### PR TITLE
feat: battle result notification parser for victory/defeat toasts

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -324,6 +324,12 @@ disable_toast_banners = false
 
 disabled_banner_types = ""
 
+# System notifications for in-game events. Comma-separated list of toast types
+# to deliver as OS-level notifications (Windows toast). Uses the same type names
+# as disabled_banner_types. Empty string = no notifications.
+# Example: "Victory, Defeat, IncomingAttack, StationBattle"
+notify_banner_types = ""
+
 # Subgroup: Chat
 # --------------
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -683,6 +683,29 @@ void Config::Load()
 
   parsed["ui"].as_table()->insert_or_assign("disabled_banner_types", bannerString);
 
+  // Parse notify_banner_types using the same bannerTypes lookup table
+  auto notify_banner_types_str =
+      get_config_or_default<std::string>(config, parsed, "ui", "notify_banner_types", DCU::notify_banner_types, write_log);
+
+  std::vector<std::string> notify_types = StrSplit(notify_banner_types_str, ',');
+  std::string              notifyString;
+
+  for (const auto& [key, value] : bannerTypes) {
+    auto upper_key = AsciiStrToUpper(key);
+    for (const std::string_view _type : notify_types) {
+      auto stripped_type = StripLeadingAsciiWhitespace(_type);
+      auto upper_type    = AsciiStrToUpper(stripped_type);
+      if (upper_key == upper_type) {
+        this->notify_banner_types.emplace_back(value);
+        if (!notifyString.empty()) notifyString.append(", ");
+        notifyString.append(key);
+      }
+    }
+  }
+
+  spdlog::debug("Final notify banner types: {}", notifyString);
+  parsed["ui"].as_table()->insert_or_assign("notify_banner_types", notifyString);
+
   spdlog::debug("");
 
   //if (this->enable_experimental) {

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -160,6 +160,7 @@ public:
 
   bool             borderless_fullscreen;
   std::vector<int> disabled_banner_types;
+  std::vector<int> notify_banner_types;
 
   int  extend_donation_max;
   bool extend_donation_slider;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -196,6 +196,7 @@ namespace UI
   constexpr bool        disable_toast_banners       = false;
   constexpr bool        disable_veil_chat           = false;
   constexpr const char* disabled_banner_types       = "";
+  constexpr const char* notify_banner_types         = "";
   constexpr auto        extend_donation_max         = 80;
   constexpr bool        extend_donation_slider      = true;
   constexpr bool        show_armada_cargo           = true;

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -1,0 +1,198 @@
+#include "patches/battle_notify_parser.h"
+
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/BattleResultHeader.h>
+#include <prime/HullSpec.h>
+#include <prime/SpecService.h>
+#include <prime/Toast.h>
+#include <prime/UserProfile.h>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// SEH wrapper — catches access violations from bad IL2CPP pointers
+// ---------------------------------------------------------------------------
+template <typename Fn>
+static bool seh_call(Fn fn)
+{
+#if _WIN32
+  __try {
+    fn();
+    return true;
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return false;
+  }
+#else
+  fn();
+  return true;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Hull name key → human-readable name
+//   "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
+// ---------------------------------------------------------------------------
+static std::string parse_hull_key(const std::string& key)
+{
+  auto s = key;
+
+  if (s.size() > 5 && s.ends_with("_LIVE"))
+    s = s.substr(0, s.size() - 5);
+
+  if (s.starts_with("Hull_"))
+    s = s.substr(5);
+
+  for (auto& c : s)
+    if (c == '_') c = ' ';
+
+  if (s.size() >= 2 && s[0] == 'L' && std::isdigit(s[1])) {
+    auto space = s.find(' ');
+    auto lvl   = s.substr(1, space == std::string::npos ? std::string::npos : space - 1);
+    auto rest  = space == std::string::npos ? "" : s.substr(space);
+    s = "Lv." + lvl + rest;
+  }
+
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Resolve hull ID → display name via SpecService
+// ---------------------------------------------------------------------------
+static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
+{
+  if (hullId == 0) return "";
+
+  auto* specSvc = reinterpret_cast<SpecService*>(brh->get_SpecService());
+  if (specSvc) {
+    auto* hull = specSvc->GetHull(hullId);
+    if (hull) {
+      auto* nameStr = hull->Name;
+      auto nameKey  = nameStr ? to_string(nameStr) : std::string{};
+      if (!nameKey.empty()) return parse_hull_key(nameKey);
+    }
+  }
+
+  return fmt::format("Hull#{}", hullId);
+}
+
+// ---------------------------------------------------------------------------
+// Format "Name (Ship) vs Name (Ship)"
+// ---------------------------------------------------------------------------
+struct BattleSummaryData {
+  std::string playerName;
+  std::string enemyName;
+  std::string playerShip;
+  std::string enemyShip;
+
+  std::string format_body() const
+  {
+    auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
+      if (name.empty()) return "";
+      if (ship.empty()) return name;
+      return fmt::format("{} ({})", name, ship);
+    };
+
+    auto left  = format_side(playerName, playerShip);
+    auto right = format_side(enemyName, enemyShip);
+    if (left.empty() && right.empty()) return "";
+    if (left.empty()) return right;
+    if (right.empty()) return left;
+    return left + " vs " + right;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Extract player/enemy names + ship hulls from BattleResultHeader
+// ---------------------------------------------------------------------------
+static BattleSummaryData build_battle_data(Il2CppObject* data)
+{
+  BattleSummaryData result;
+  if (!data) return result;
+
+  auto* brh = reinterpret_cast<BattleResultHeader*>(data);
+
+  if (!seh_call([&] {
+        auto* p       = brh->get_PlayerUserProfile();
+        auto* profile = reinterpret_cast<UserProfile*>(p);
+        if (profile) {
+          auto* nameStr = profile->Name;
+          if (nameStr) result.playerName = to_string(nameStr);
+          if (result.playerName.empty()) {
+            auto locaId = profile->LocaId;
+            if (locaId > 0) result.playerName = fmt::format("NPC#{}", locaId);
+          }
+        }
+      }))
+    spdlog::warn("[Notify] SEH: get_PlayerUserProfile crashed");
+
+  if (!seh_call([&] {
+        auto* e       = brh->get_EnemyUserProfile();
+        auto* profile = reinterpret_cast<UserProfile*>(e);
+        if (profile) {
+          auto* nameStr = profile->Name;
+          if (nameStr) result.enemyName = to_string(nameStr);
+          if (result.enemyName.empty()) {
+            auto locaId = profile->LocaId;
+            if (locaId > 0) result.enemyName = fmt::format("NPC#{}", locaId);
+          }
+        }
+      }))
+    spdlog::warn("[Notify] SEH: get_EnemyUserProfile crashed");
+
+  if (!seh_call([&] {
+        auto hid          = brh->PlayerShipHullId;
+        result.playerShip = resolve_hull_name(brh, hid);
+      }))
+    spdlog::warn("[Notify] SEH: PlayerShipHullId crashed");
+
+  if (!seh_call([&] {
+        auto hid         = brh->EnemyShipHullId;
+        result.enemyShip = resolve_hull_name(brh, hid);
+      }))
+    spdlog::warn("[Notify] SEH: EnemyShipHullId crashed");
+
+  spdlog::info("[Notify] Battle: {} ({}) vs {} ({})", result.playerName, result.playerShip,
+               result.enemyName, result.enemyShip);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+std::string battle_notify_parse(Toast* toast)
+{
+  auto state = toast->get_State();
+
+  switch (state) {
+    case Victory:
+    case Defeat:
+    case PartialVictory:
+    case StationVictory:
+    case StationDefeat:
+    case StationBattle:
+    case IncomingAttack:
+    case FleetBattle:
+    case ArmadaBattleWon:
+    case ArmadaBattleLost:
+    case AssaultVictory:
+    case AssaultDefeat:
+      break;
+    default:
+      return {};
+  }
+
+  auto* data = toast->get_Data();
+  if (!data) return {};
+
+  auto bsd = build_battle_data(data);
+  return bsd.format_body();
+}

--- a/mods/src/patches/battle_notify_parser.h
+++ b/mods/src/patches/battle_notify_parser.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+struct Toast;
+
+// Attempt to build a detailed notification body from a battle toast's Data.
+// Returns empty string if the toast has no battle data or parsing fails.
+std::string battle_notify_parse(Toast* toast);

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,0 +1,205 @@
+#include "patches/notification_service.h"
+
+#include "config.h"
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/LanguageManager.h>
+#include <prime/Toast.h>
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#include <winrt/Windows.Data.Xml.Dom.h>
+#include <winrt/Windows.UI.Notifications.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// IL2CPP method cache
+// ---------------------------------------------------------------------------
+static const MethodInfo* s_localize_ltc = nullptr;
+
+// ---------------------------------------------------------------------------
+// Toast state → human-readable title
+// ---------------------------------------------------------------------------
+static const char* toast_state_title(int state)
+{
+  switch (state) {
+    case Victory:                   return "Victory!";
+    case Defeat:                    return "Defeat";
+    case PartialVictory:            return "Partial Victory";
+    case StationVictory:            return "Station Victory!";
+    case StationDefeat:             return "Station Defeat";
+    case StationBattle:             return "Station Under Attack!";
+    case IncomingAttack:            return "Incoming Attack!";
+    case IncomingAttackFaction:     return "Incoming Faction Attack!";
+    case FleetBattle:               return "Fleet Battle";
+    case ArmadaBattleWon:           return "Armada Victory!";
+    case ArmadaBattleLost:          return "Armada Defeated";
+    case ArmadaCreated:             return "Armada Created";
+    case ArmadaCanceled:            return "Armada Canceled";
+    case ArmadaIncomingAttack:      return "Armada Under Attack!";
+    case AssaultVictory:            return "Assault Victory!";
+    case AssaultDefeat:             return "Assault Defeat";
+    case Tournament:                return "Event Progress";
+    case ChainedEventScored:        return "Event Progress";
+    case Achievement:               return "Achievement";
+    case ChallengeComplete:         return "Challenge Complete";
+    case ChallengeFailed:           return "Challenge Failed";
+    case TakeoverVictory:           return "Takeover Victory!";
+    case TakeoverDefeat:            return "Takeover Defeat";
+    case TreasuryProgress:          return "Treasury Progress";
+    case TreasuryFull:              return "Treasury Full";
+    case WarchestProgress:          return "Warchest Progress";
+    case WarchestFull:              return "Warchest Full";
+    case FactionLevelUp:            return "Faction Level Up";
+    case FactionLevelDown:          return "Faction Level Down";
+    case FactionDiscovered:         return "Faction Discovered";
+    case FactionWarning:            return "Faction Warning";
+    case DiplomacyUpdated:          return "Diplomacy Updated";
+    case StrikeHit:                 return "Strike Hit";
+    case StrikeDefeat:              return "Strike Defeat";
+    case SurgeWarmUpEnded:          return "Surge Started";
+    case SurgeHostileGroupDefeated: return "Surge Hostiles Defeated";
+    case SurgeTimeLeft:             return "Surge Time Warning";
+    case ArenaTimeLeft:             return "Arena Time Warning";
+    case FleetPresetApplied:        return "Fleet Preset Applied";
+    default:                        return nullptr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform notification delivery
+// ---------------------------------------------------------------------------
+#if _WIN32
+static void show_system_notification(const char* title, const char* body)
+{
+  try {
+    using namespace winrt::Windows::UI::Notifications;
+    using namespace winrt::Windows::Data::Xml::Dom;
+
+    auto xml   = ToastNotificationManager::GetTemplateContent(ToastTemplateType::ToastText02);
+    auto nodes = xml.GetElementsByTagName(L"text");
+    nodes.Item(0).InnerText(winrt::to_hstring(title));
+    nodes.Item(1).InnerText(winrt::to_hstring(body));
+
+    auto notification = ToastNotification(xml);
+    auto notifier     = ToastNotificationManager::CreateToastNotifier(L"Star Trek Fleet Command");
+    notifier.Show(notification);
+  } catch (const winrt::hresult_error& e) {
+    spdlog::warn("[Notify] WinRT notification failed: {}", winrt::to_string(e.message()));
+  } catch (...) {
+    spdlog::warn("[Notify] WinRT notification failed (unknown error)");
+  }
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// Resolve basic localized text from a Toast's TextLocaleTextContext
+// ---------------------------------------------------------------------------
+static std::string resolve_toast_text(Toast* toast)
+{
+  if (!s_localize_ltc) return {};
+
+  auto* ltc = toast->get_TextLocaleTextContext();
+  if (!ltc) return {};
+
+  auto* langMgr = LanguageManager::Instance();
+  if (!langMgr) return {};
+
+  Il2CppString*  resolved = nullptr;
+  void*          params[2] = { &resolved, ltc };
+  Il2CppException* exc = nullptr;
+  il2cpp_runtime_invoke(s_localize_ltc, langMgr, params, &exc);
+
+  if (exc || !resolved) return {};
+  return to_string(resolved);
+}
+
+// ---------------------------------------------------------------------------
+// Strip Unity rich text tags (e.g. <color=#FF0000>, <b>, </size>)
+// ---------------------------------------------------------------------------
+static std::string strip_unity_rich_text(const std::string& s)
+{
+  std::string result;
+  result.reserve(s.size());
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '<') {
+      auto end = s.find('>', i);
+      if (end != std::string::npos) { i = end + 1; continue; }
+    }
+    result += s[i++];
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void notification_init()
+{
+  // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
+  // 2-parameter overload that takes an LTC and returns a localized string.
+  auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
+  if (lm_helper.isValidHelper()) {
+    auto* cls = lm_helper.get_cls();
+    if (cls) {
+      void* iter = nullptr;
+      while (auto* method = il2cpp_class_get_methods(cls, &iter)) {
+        auto name = std::string_view(il2cpp_method_get_name(method));
+        auto pc   = il2cpp_method_get_param_count(method);
+        if (name == "Localize" && pc == 2) {
+          s_localize_ltc = method;
+          spdlog::info("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
+          break;
+        }
+      }
+    }
+  }
+
+  if (!s_localize_ltc) {
+    spdlog::warn("[Notify] Could not resolve LanguageManager::Localize — notifications will show titles only");
+  }
+
+#if _WIN32
+  try { winrt::init_apartment(); } catch (...) {}
+  spdlog::info("[Notify] Windows notification service initialized");
+#else
+  spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+}
+
+void notification_handle_toast(Toast* toast)
+{
+#if !_WIN32
+  return; // No notification delivery on non-Windows platforms yet
+#else
+  auto state = toast->get_State();
+
+  // Check if this toast type is in the user's notify list
+  const auto& notify_types = Config::Get().notify_banner_types;
+  if (std::ranges::find(notify_types, state) == notify_types.end()) {
+    return;
+  }
+
+  auto* title = toast_state_title(state);
+  if (!title) {
+    spdlog::debug("[Notify] No title mapping for toast state {}, skipping", state);
+    return;
+  }
+
+  auto body = strip_unity_rich_text(resolve_toast_text(toast));
+  if (body.empty()) {
+    body = "(no details available)";
+  }
+
+  spdlog::info("[Notify] {} — {}", title, body);
+  show_system_notification(title, body.c_str());
+#endif
+}

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,4 +1,5 @@
 #include "patches/notification_service.h"
+#include "patches/battle_notify_parser.h"
 
 #include "config.h"
 #include "str_utils.h"
@@ -194,7 +195,10 @@ void notification_handle_toast(Toast* toast)
     return;
   }
 
-  auto body = strip_unity_rich_text(resolve_toast_text(toast));
+  auto body = battle_notify_parse(toast);
+  if (body.empty()) {
+    body = strip_unity_rich_text(resolve_toast_text(toast));
+  }
   if (body.empty()) {
     body = "(no details available)";
   }

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -1,0 +1,10 @@
+#pragma once
+
+struct Toast;
+
+// Initialize the notification service (resolve IL2CPP methods, init platform).
+// Call once during InstallToastBannerHooks().
+void notification_init();
+
+// Called from toast hooks — checks config, formats, and delivers notification.
+void notification_handle_toast(Toast* toast);

--- a/mods/src/patches/parts/disable_banners.cc
+++ b/mods/src/patches/parts/disable_banners.cc
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "errormsg.h"
+#include "patches/notification_service.h"
 
 #include <il2cpp/il2cpp_helper.h>
 #include <prime/Toast.h>
@@ -11,6 +12,8 @@ struct ToastObserver {
 
 void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast *toast)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -21,6 +24,8 @@ void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast 
 
 void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_this, Toast *toast, uintptr_t cmpAction)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -31,6 +36,8 @@ void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_thi
 
 void InstallToastBannerHooks()
 {
+  notification_init();
+
   if (auto helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "ToastObserver");
       !helper.isValidHelper()) {
     ErrorMsg::MissingHelper("HUD", "ToastObserver");

--- a/mods/src/prime/BattleResultHeader.h
+++ b/mods/src/prime/BattleResultHeader.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+enum class BattleType {
+  Fleet                          = 0,
+  Base                           = 1,
+  PassiveMarauder                = 2,
+  NpcInstantiated                = 3,
+  DockingPoint                   = 4,
+  ActiveMarauder_MarauderInit    = 5,
+  ActiveMarauder_PlayerInit      = 6,
+  ArmadaBase                     = 7,
+  ArmadaMarauder                 = 8,
+  PveDockingPoint                = 9,
+  ArmadaAsb                      = 10,
+  ArmadaMta                      = 11,
+  Hazard                         = 12,
+  PveCuttingBeam                 = 13,
+  PvpCuttingBeam                 = 14,
+  PveChainShot                   = 15,
+  PvpChainShot                   = 16
+};
+
+enum class BattleResultType {
+  Defeat         = 0,
+  Victory        = 1,
+  PartialVictory = 2
+};
+
+enum class FleetDataType {
+  DeployedFleet = 0,
+  Starbase      = 1,
+  Armada        = 2
+};
+
+struct BattleResultHeader {
+public:
+  __declspec(property(get = __get_PlayerShipHullId)) long PlayerShipHullId;
+  __declspec(property(get = __get_EnemyShipHullId)) long EnemyShipHullId;
+
+  Il2CppObject* get_PlayerUserProfile()
+  {
+    static auto prop = get_class_helper().GetProperty("PlayerUserProfile");
+    return prop.GetRaw<Il2CppObject>(this);
+  }
+
+  Il2CppObject* get_EnemyUserProfile()
+  {
+    static auto prop = get_class_helper().GetProperty("EnemyUserProfile");
+    return prop.GetRaw<Il2CppObject>(this);
+  }
+
+  Il2CppObject* get_SpecService()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x18);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "BattleResultHeader");
+    return class_helper;
+  }
+
+public:
+  long __get_PlayerShipHullId()
+  {
+    static auto prop = get_class_helper().GetProperty("PlayerShipHullId");
+    return *prop.Get<long>(this);
+  }
+
+  long __get_EnemyShipHullId()
+  {
+    static auto prop = get_class_helper().GetProperty("EnemyShipHullId");
+    return *prop.Get<long>(this);
+  }
+};

--- a/mods/src/prime/HullSpec.h
+++ b/mods/src/prime/HullSpec.h
@@ -15,6 +15,7 @@ enum class HullType {
 struct HullSpec {
 public:
   __declspec(property(get = __get_Id)) long Id;
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
   __declspec(property(get = __get_Type)) HullType Type;
 
 private:
@@ -32,9 +33,15 @@ public:
     return *(long*)((char*)this + field);
   }
 
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+
   HullType __get_Type()
   {
-    static auto field = get_class_helper().GetProperty("Type");
-    return *field.Get<HullType>(this);
+    static auto prop = get_class_helper().GetProperty("Type");
+    return *prop.Get<HullType>(this);
   }
 };

--- a/mods/src/prime/SpecService.h
+++ b/mods/src/prime/SpecService.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+#include "HullSpec.h"
+
+struct SpecService {
+public:
+  HullSpec* GetHull(long hullId)
+  {
+    static auto method =
+        get_class_helper().GetMethod<HullSpec*(SpecService*, long)>("GetHull");
+    return method(this, hullId);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Services", "SpecService");
+    return class_helper;
+  }
+};

--- a/mods/src/prime/Toast.h
+++ b/mods/src/prime/Toast.h
@@ -50,6 +50,16 @@ enum ToastState {
 
 struct Toast {
 public:
+  void* get_TextLocaleTextContext()
+  {
+    return *reinterpret_cast<void**>(reinterpret_cast<char*>(this) + 0x20);
+  }
+
+  Il2CppObject* get_Data()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x38);
+  }
+
   int get_State()
   {
     static auto prop = get_class_helper().GetProperty("State");

--- a/mods/src/prime/UserProfile.h
+++ b/mods/src/prime/UserProfile.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct UserProfile {
+public:
+  __declspec(property(get = __get_LocaId)) long LocaId;
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "UserProfile");
+    return class_helper;
+  }
+
+public:
+  long __get_LocaId()
+  {
+    static auto field = get_class_helper().GetField("_locaId").offset();
+    return *(long*)((char*)this + field);
+  }
+
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+};


### PR DESCRIPTION
## Summary

Adds a battle result parser that provides rich notification bodies for victory/defeat toasts. Instead of generic localized text, battle notifications now show **"Player (Ship) vs Enemy (Ship)"**.

## What Changed

### New Files
- **`mods/src/patches/battle_notify_parser.h/.cc`** — `battle_notify_parse(Toast*)` extracts player/enemy names and ship hull names from `BattleResultHeader` data
  - `build_battle_data()` — extracts `UserProfile::Name` (with `LocaId` NPC fallback) and hull names via `SpecService::GetHull()`
  - `resolve_hull_name()` — resolves hull ID → `HullSpec::Name` → `parse_hull_key()` for human-readable format
  - `BattleSummaryData::format_body()` — formats "Player (Ship) vs Enemy (Ship)"
  - Every IL2CPP property access wrapped in SEH guards for crash safety
- **`mods/src/prime/BattleResultHeader.h`** — `BattleResultHeader` with player/enemy profile + hull ID accessors, `BattleType`/`BattleResultType`/`FleetDataType` enums
- **`mods/src/prime/UserProfile.h`** — `UserProfile` with `Name` and `LocaId`
- **`mods/src/prime/SpecService.h`** — `SpecService::GetHull(long)` → `HullSpec*`

### Modified Files
- **`mods/src/prime/HullSpec.h`** — Added `Name` property for hull name resolution
- **`mods/src/patches/notification_service.cc`** — Tries `battle_notify_parse()` first, falls back to generic `resolve_toast_text()` for non-battle toasts

## Handled Toast States
Victory, Defeat, PartialVictory, StationVictory, StationDefeat, StationBattle, IncomingAttack, FleetBattle, ArmadaBattleWon, ArmadaBattleLost, AssaultVictory, AssaultDefeat

## Tested
Deployed and confirmed working in-game — victory/defeat notifications show player and enemy names with ship types.

## BLOCKED BY
- #130 (fix/duplicate-hook-target — ProcessResultInternal guard)
- #131 (feature/notification-framework — notification service API)