### PR TITLE
Fix verify_ssl not working without proxy and not parsed per-target

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -336,13 +336,15 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
         continue;
       }
 
-      target.url   = url.value();
-      target.token = token.value();
-      target.proxy = proxy.value_or(defaults.proxy);
+      target.url        = url.value();
+      target.token      = token.value();
+      target.proxy      = proxy.value_or(defaults.proxy);
+      target.verify_ssl = values["verify_ssl"].value<bool>().value_or(defaults.verify_ssl);
 
       parsed_target.insert("url", target.url);
       parsed_target.insert("token", target.token);
       parsed_target.insert("proxy", target.proxy);
+      parsed_target.insert("verify_ssl", target.verify_ssl);
     } else {
       spdlog::warn("Skipping invalid target [{}]. Missing url or token.", target_section);
       continue;
@@ -356,6 +358,7 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
     if (sync_targets.emplace(target_key.str(), target).second) {
       new_config["sync"]["targets"].as_table()->emplace<toml::table>(target_key.str(), parsed_target);
       spdlog::debug("config value {} url: {}, token: {}", target_section, target.url, mask_token(target.token));
+      spdlog::info("target [{}] proxy: '{}', verify_ssl: {}", target_section, target.proxy, target.verify_ssl);
     }
   }
 }
@@ -633,6 +636,9 @@ void Config::Load()
 
   // set global sync options to what's actually used in targets
   const auto targets_view = this->sync_targets | std::views::values;
+
+  this->sync_options.proxy      = sync_defaults.proxy;
+  this->sync_options.verify_ssl = sync_defaults.verify_ssl;
 
   for (const auto& opt : SyncOptions) {
     this->sync_options.*opt.option =

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -331,14 +331,16 @@ static std::shared_ptr<TargetWorker> get_curl_client_sync(const std::string& tar
   worker->session->SetTimeout(cpr::Timeout{10'000});
 #endif
 
+  spdlog::debug("sync target '{}': proxy='{}', verify_ssl={}", target, target_config.proxy, target_config.verify_ssl);
+
   if (!target_config.proxy.empty()) {
     worker->session->SetProxies({{"http", target_config.proxy}, {"https", target_config.proxy}});
+  }
 
-    if (!target_config.verify_ssl) {
-      worker->session->SetSslOptions(
-        cpr::Ssl(cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyPeer{false}, cpr::ssl::NoRevoke{true})
-      );
-    }
+  if (!target_config.verify_ssl) {
+    worker->session->SetSslOptions(
+      cpr::Ssl(cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyPeer{false}, cpr::ssl::NoRevoke{true})
+    );
   }
 
   worker->session->SetHeader({
@@ -404,14 +406,16 @@ static std::shared_ptr<cpr::Session> get_curl_client_scopely()
     session->SetAcceptEncoding(cpr::AcceptEncoding{});
     session->SetHttpVersion(cpr::HttpVersion{cpr::HttpVersionCode::VERSION_1_1});
 
+    spdlog::debug("scopely session: proxy='{}', verify_ssl={}", Config::Get().sync_options.proxy, Config::Get().sync_options.verify_ssl);
+
     if (!Config::Get().sync_options.proxy.empty()) {
       session->SetProxies({{"https", Config::Get().sync_options.proxy}});
+    }
 
-      if (!Config::Get().sync_options.verify_ssl) {
-        session->SetSslOptions(
-          cpr::Ssl(cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyPeer{false}, cpr::ssl::NoRevoke{true})
-        );
-      }
+    if (!Config::Get().sync_options.verify_ssl) {
+      session->SetSslOptions(
+        cpr::Ssl(cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyPeer{false}, cpr::ssl::NoRevoke{true})
+      );
     }
 
     session->SetUserAgent("UnityPlayer/" + headers::unityVersion + " (UnityWebRequest/1.0, libcurl/8.10.1-DEV)");


### PR DESCRIPTION
Address 3 issues:

1. verify_ssl was not parsed from per-target config in read_sync_targets(), so setting verify_ssl under [sync.targets.<name>] had no effect. It now falls back to the [sync] section default when not specified per-target.

2. SetSslOptions (which disables SSL host/peer verification and revocation checks) was only applied inside the proxy block, so verify_ssl = false had no effect unless a proxy was also configured. The SSL options are now applied independently of the proxy setting.

3. sync_options.proxy and sync_options.verify_ssl (used by the scopely session) were never populated from the [sync] config section. They now inherit from sync_defaults.

In short, this PR makes the option of disabling SSL verification during sync more robust.