### PR TITLE
feat: OS-level notifications for game events (battles, fleet arrivals)

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -324,6 +324,12 @@ disable_toast_banners = false
 
 disabled_banner_types = ""
 
+# System notifications for in-game events. Comma-separated list of toast types
+# to deliver as OS-level notifications (Windows toast). Uses the same type names
+# as disabled_banner_types. Empty string = no notifications.
+# Example: "Victory, Defeat, IncomingAttack, StationBattle"
+notify_banner_types = ""
+
 # Subgroup: Chat
 # --------------
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -689,6 +689,29 @@ void Config::Load()
 
   parsed["ui"].as_table()->insert_or_assign("disabled_banner_types", bannerString);
 
+  // Parse notify_banner_types using the same bannerTypes lookup table
+  auto notify_banner_types_str =
+      get_config_or_default<std::string>(config, parsed, "ui", "notify_banner_types", DCU::notify_banner_types, write_log);
+
+  std::vector<std::string> notify_types = StrSplit(notify_banner_types_str, ',');
+  std::string              notifyString;
+
+  for (const auto& [key, value] : bannerTypes) {
+    auto upper_key = AsciiStrToUpper(key);
+    for (const std::string_view _type : notify_types) {
+      auto stripped_type = StripLeadingAsciiWhitespace(_type);
+      auto upper_type    = AsciiStrToUpper(stripped_type);
+      if (upper_key == upper_type) {
+        this->notify_banner_types.emplace_back(value);
+        if (!notifyString.empty()) notifyString.append(", ");
+        notifyString.append(key);
+      }
+    }
+  }
+
+  spdlog::debug("Final notify banner types: {}", notifyString);
+  parsed["ui"].as_table()->insert_or_assign("notify_banner_types", notifyString);
+
   spdlog::debug("");
 
   //if (this->enable_experimental) {

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -496,6 +496,7 @@ void Config::Load()
   this->installResolutionListFix = get_config_or_default(config, parsed, "patches", "resolutionlistfix", DCP::resolutionlistfix, write_config);
   this->installSyncPatches       = get_config_or_default(config, parsed, "patches", "syncpatches", DCP::syncpatches, write_config);
   this->installObjectTracker     = get_config_or_default(config, parsed, "patches", "objecttracker", DCP::objecttracker, write_config);
+  this->installFleetArrivalHooks = get_config_or_default(config, parsed, "patches", "fleetarrivalhooks", DCP::fleetarrivalhooks, write_config);
   spdlog::debug("");
 #else
   this->installUiScaleHooks               = true;
@@ -513,6 +514,7 @@ void Config::Load()
   this->installResolutionListFix          = true;
   this->installSyncPatches                = true;
   this->installObjectTracker              = true;
+  this->installFleetArrivalHooks          = true;
 #endif
   
   this->queue_enabled       = get_config_or_default(config, parsed, "control", "queue_enabled", DCC::queue_enabled, write_config);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -160,6 +160,7 @@ public:
 
   bool             borderless_fullscreen;
   std::vector<int> disabled_banner_types;
+  std::vector<int> notify_banner_types;
 
   int  extend_donation_max;
   bool extend_donation_slider;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -203,6 +203,7 @@ public:
   bool installResolutionListFix;
   bool installSyncPatches;
   bool installObjectTracker;
+  bool installFleetArrivalHooks;
 
   std::string config_settings_url;
   std::string config_assets_url_override;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -48,23 +48,24 @@ namespace Graphics
 
 namespace Patches
 {
-  constexpr bool bufffixhooks               = true;
-  constexpr bool chatpatches                = true;
-  constexpr bool freeresizehooks            = true;
-  constexpr bool hotkeyhooks                = true;
-  constexpr bool improveresponsivenesshooks = true;
-  constexpr bool miscpatches                = true;
-  constexpr bool objecttracker              = true;
-  constexpr bool panhooks                   = true;
-  constexpr bool resolutionlistfix          = true;
-  constexpr bool syncpatches                = true;
-  constexpr bool tempcrashfixes             = true;
-  constexpr bool testpatches                = true;
-  constexpr bool toastbannerhooks           = true;
-  constexpr bool uiscalehooks               = true;
-  constexpr bool zoomhooks                  = true;
-} // namespace Patches
-
+  // Debug-build toggles for individual hook categories.
+  // In release builds these are ignored and all patches are force-enabled.
+  constexpr bool bufffixhooks               = true;  ///< Out-of-dock power / buff calculation fixes.
+  constexpr bool chatpatches                = true;  ///< Chat-related UI patches.
+  constexpr bool freeresizehooks            = true;  ///< Free window resize hooks.
+  constexpr bool hotkeyhooks                = true;  ///< Keyboard hotkey injection.
+  constexpr bool improveresponsivenesshooks = true;  ///< Input-responsiveness improvements.
+  constexpr bool miscpatches                = true;  ///< Misc one-off fixes.
+  constexpr bool objecttracker              = true;  ///< In-system object tracking overlay.
+  constexpr bool fleetarrivalhooks          = true;  ///< Fleet arrival detection from the bottom fleet bar.
+  constexpr bool panhooks                   = true;  ///< Pan-momentum hooks.
+  constexpr bool resolutionlistfix          = true;  ///< Resolution-list population fix.
+  constexpr bool syncpatches                = true;  ///< Data-sync network hooks.
+  constexpr bool tempcrashfixes             = true;  ///< Temporary crash mitigations.
+  constexpr bool testpatches                = true;  ///< Test / experimental patches.
+  constexpr bool toastbannerhooks           = true;  ///< Toast-banner filtering hooks.
+  constexpr bool uiscalehooks               = true;  ///< UI scale override hooks.
+  constexpr bool zoomhooks                  = true;  ///< Camera zoom override hooks.
 namespace Shortcuts
 {
   constexpr const char* toggle_queue          = "CTRL-Q";

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -196,6 +196,7 @@ namespace UI
   constexpr bool        disable_toast_banners       = false;
   constexpr bool        disable_veil_chat           = false;
   constexpr const char* disabled_banner_types       = "";
+  constexpr const char* notify_banner_types         = "";
   constexpr auto        extend_donation_max         = 80;
   constexpr bool        extend_donation_slider      = true;
   constexpr bool        show_armada_cargo           = true;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -66,6 +66,8 @@ namespace Patches
   constexpr bool toastbannerhooks           = true;  ///< Toast-banner filtering hooks.
   constexpr bool uiscalehooks               = true;  ///< UI scale override hooks.
   constexpr bool zoomhooks                  = true;  ///< Camera zoom override hooks.
+} // namespace Patches
+
 namespace Shortcuts
 {
   constexpr const char* toggle_queue          = "CTRL-Q";

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -72,14 +72,14 @@ static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
   if (hullId == 0) return "";
 
   auto* specSvc = reinterpret_cast<SpecService*>(brh->get_SpecService());
-  if (specSvc) {
-    auto* hull = specSvc->GetHull(hullId);
-    if (hull) {
-      auto* nameStr = hull->Name;
-      auto nameKey  = nameStr ? to_string(nameStr) : std::string{};
-      if (!nameKey.empty()) return parse_hull_key(nameKey);
-    }
-  }
+  if (!specSvc) return fmt::format("Hull#{}", hullId);
+
+  auto* hull = specSvc->GetHull(hullId);
+  if (!hull) return fmt::format("Hull#{}", hullId);
+
+  auto* nameStr = hull->Name;
+  auto nameKey  = nameStr ? to_string(nameStr) : std::string{};
+  if (!nameKey.empty()) return parse_hull_key(nameKey);
 
   return fmt::format("Hull#{}", hullId);
 }
@@ -93,12 +93,15 @@ struct BattleSummaryData {
   std::string playerShip;
   std::string enemyShip;
 
+  /** @brief Format the summary as "Player (Ship) vs Enemy (Ship)".
+   *  For NPCs (empty name), uses the ship hull name as the identifier. */
   std::string format_body() const
   {
     auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
-      if (name.empty()) return "";
-      if (ship.empty()) return name;
-      return fmt::format("{} ({})", name, ship);
+      if (!name.empty() && !ship.empty()) return fmt::format("{} ({})", name, ship);
+      if (!name.empty()) return name;
+      if (!ship.empty()) return ship;
+      return "";
     };
 
     auto left  = format_side(playerName, playerShip);
@@ -126,10 +129,7 @@ static BattleSummaryData build_battle_data(Il2CppObject* data)
         if (profile) {
           auto* nameStr = profile->Name;
           if (nameStr) result.playerName = to_string(nameStr);
-          if (result.playerName.empty()) {
-            auto locaId = profile->LocaId;
-            if (locaId > 0) result.playerName = fmt::format("NPC#{}", locaId);
-          }
+          // NPC profiles have empty names — leave blank, hull name used instead
         }
       }))
     spdlog::warn("[Notify] SEH: get_PlayerUserProfile crashed");
@@ -140,10 +140,7 @@ static BattleSummaryData build_battle_data(Il2CppObject* data)
         if (profile) {
           auto* nameStr = profile->Name;
           if (nameStr) result.enemyName = to_string(nameStr);
-          if (result.enemyName.empty()) {
-            auto locaId = profile->LocaId;
-            if (locaId > 0) result.enemyName = fmt::format("NPC#{}", locaId);
-          }
+          // NPC profiles have empty names — leave blank, hull name used instead
         }
       }))
     spdlog::warn("[Notify] SEH: get_EnemyUserProfile crashed");

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -1,0 +1,198 @@
+#include "patches/battle_notify_parser.h"
+
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/BattleResultHeader.h>
+#include <prime/HullSpec.h>
+#include <prime/SpecService.h>
+#include <prime/Toast.h>
+#include <prime/UserProfile.h>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// SEH wrapper — catches access violations from bad IL2CPP pointers
+// ---------------------------------------------------------------------------
+template <typename Fn>
+static bool seh_call(Fn fn)
+{
+#if _WIN32
+  __try {
+    fn();
+    return true;
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return false;
+  }
+#else
+  fn();
+  return true;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Hull name key → human-readable name
+//   "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
+// ---------------------------------------------------------------------------
+static std::string parse_hull_key(const std::string& key)
+{
+  auto s = key;
+
+  if (s.size() > 5 && s.ends_with("_LIVE"))
+    s = s.substr(0, s.size() - 5);
+
+  if (s.starts_with("Hull_"))
+    s = s.substr(5);
+
+  for (auto& c : s)
+    if (c == '_') c = ' ';
+
+  if (s.size() >= 2 && s[0] == 'L' && std::isdigit(s[1])) {
+    auto space = s.find(' ');
+    auto lvl   = s.substr(1, space == std::string::npos ? std::string::npos : space - 1);
+    auto rest  = space == std::string::npos ? "" : s.substr(space);
+    s = "Lv." + lvl + rest;
+  }
+
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Resolve hull ID → display name via SpecService
+// ---------------------------------------------------------------------------
+static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
+{
+  if (hullId == 0) return "";
+
+  auto* specSvc = reinterpret_cast<SpecService*>(brh->get_SpecService());
+  if (specSvc) {
+    auto* hull = specSvc->GetHull(hullId);
+    if (hull) {
+      auto* nameStr = hull->Name;
+      auto nameKey  = nameStr ? to_string(nameStr) : std::string{};
+      if (!nameKey.empty()) return parse_hull_key(nameKey);
+    }
+  }
+
+  return fmt::format("Hull#{}", hullId);
+}
+
+// ---------------------------------------------------------------------------
+// Format "Name (Ship) vs Name (Ship)"
+// ---------------------------------------------------------------------------
+struct BattleSummaryData {
+  std::string playerName;
+  std::string enemyName;
+  std::string playerShip;
+  std::string enemyShip;
+
+  std::string format_body() const
+  {
+    auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
+      if (name.empty()) return "";
+      if (ship.empty()) return name;
+      return fmt::format("{} ({})", name, ship);
+    };
+
+    auto left  = format_side(playerName, playerShip);
+    auto right = format_side(enemyName, enemyShip);
+    if (left.empty() && right.empty()) return "";
+    if (left.empty()) return right;
+    if (right.empty()) return left;
+    return left + " vs " + right;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Extract player/enemy names + ship hulls from BattleResultHeader
+// ---------------------------------------------------------------------------
+static BattleSummaryData build_battle_data(Il2CppObject* data)
+{
+  BattleSummaryData result;
+  if (!data) return result;
+
+  auto* brh = reinterpret_cast<BattleResultHeader*>(data);
+
+  if (!seh_call([&] {
+        auto* p       = brh->get_PlayerUserProfile();
+        auto* profile = reinterpret_cast<UserProfile*>(p);
+        if (profile) {
+          auto* nameStr = profile->Name;
+          if (nameStr) result.playerName = to_string(nameStr);
+          if (result.playerName.empty()) {
+            auto locaId = profile->LocaId;
+            if (locaId > 0) result.playerName = fmt::format("NPC#{}", locaId);
+          }
+        }
+      }))
+    spdlog::warn("[Notify] SEH: get_PlayerUserProfile crashed");
+
+  if (!seh_call([&] {
+        auto* e       = brh->get_EnemyUserProfile();
+        auto* profile = reinterpret_cast<UserProfile*>(e);
+        if (profile) {
+          auto* nameStr = profile->Name;
+          if (nameStr) result.enemyName = to_string(nameStr);
+          if (result.enemyName.empty()) {
+            auto locaId = profile->LocaId;
+            if (locaId > 0) result.enemyName = fmt::format("NPC#{}", locaId);
+          }
+        }
+      }))
+    spdlog::warn("[Notify] SEH: get_EnemyUserProfile crashed");
+
+  if (!seh_call([&] {
+        auto hid          = brh->PlayerShipHullId;
+        result.playerShip = resolve_hull_name(brh, hid);
+      }))
+    spdlog::warn("[Notify] SEH: PlayerShipHullId crashed");
+
+  if (!seh_call([&] {
+        auto hid         = brh->EnemyShipHullId;
+        result.enemyShip = resolve_hull_name(brh, hid);
+      }))
+    spdlog::warn("[Notify] SEH: EnemyShipHullId crashed");
+
+  spdlog::info("[Notify] Battle: {} ({}) vs {} ({})", result.playerName, result.playerShip,
+               result.enemyName, result.enemyShip);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+std::string battle_notify_parse(Toast* toast)
+{
+  auto state = toast->get_State();
+
+  switch (state) {
+    case Victory:
+    case Defeat:
+    case PartialVictory:
+    case StationVictory:
+    case StationDefeat:
+    case StationBattle:
+    case IncomingAttack:
+    case FleetBattle:
+    case ArmadaBattleWon:
+    case ArmadaBattleLost:
+    case AssaultVictory:
+    case AssaultDefeat:
+      break;
+    default:
+      return {};
+  }
+
+  auto* data = toast->get_Data();
+  if (!data) return {};
+
+  auto bsd = build_battle_data(data);
+  return bsd.format_body();
+}

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -157,8 +157,8 @@ static BattleSummaryData build_battle_data(Il2CppObject* data)
       }))
     spdlog::warn("[Notify] SEH: EnemyShipHullId crashed");
 
-  spdlog::info("[Notify] Battle: {} ({}) vs {} ({})", result.playerName, result.playerShip,
-               result.enemyName, result.enemyShip);
+  spdlog::debug("[Notify] Battle: {} ({}) vs {} ({})", result.playerName, result.playerShip,
+                result.enemyName, result.enemyShip);
   return result;
 }
 

--- a/mods/src/patches/battle_notify_parser.h
+++ b/mods/src/patches/battle_notify_parser.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+struct Toast;
+
+// Attempt to build a detailed notification body from a battle toast's Data.
+// Returns empty string if the toast has no battle data or parsing fails.
+std::string battle_notify_parse(Toast* toast);

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,0 +1,205 @@
+#include "patches/notification_service.h"
+
+#include "config.h"
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/LanguageManager.h>
+#include <prime/Toast.h>
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#include <winrt/Windows.Data.Xml.Dom.h>
+#include <winrt/Windows.UI.Notifications.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// IL2CPP method cache
+// ---------------------------------------------------------------------------
+static const MethodInfo* s_localize_ltc = nullptr;
+
+// ---------------------------------------------------------------------------
+// Toast state → human-readable title
+// ---------------------------------------------------------------------------
+static const char* toast_state_title(int state)
+{
+  switch (state) {
+    case Victory:                   return "Victory!";
+    case Defeat:                    return "Defeat";
+    case PartialVictory:            return "Partial Victory";
+    case StationVictory:            return "Station Victory!";
+    case StationDefeat:             return "Station Defeat";
+    case StationBattle:             return "Station Under Attack!";
+    case IncomingAttack:            return "Incoming Attack!";
+    case IncomingAttackFaction:     return "Incoming Faction Attack!";
+    case FleetBattle:               return "Fleet Battle";
+    case ArmadaBattleWon:           return "Armada Victory!";
+    case ArmadaBattleLost:          return "Armada Defeated";
+    case ArmadaCreated:             return "Armada Created";
+    case ArmadaCanceled:            return "Armada Canceled";
+    case ArmadaIncomingAttack:      return "Armada Under Attack!";
+    case AssaultVictory:            return "Assault Victory!";
+    case AssaultDefeat:             return "Assault Defeat";
+    case Tournament:                return "Event Progress";
+    case ChainedEventScored:        return "Event Progress";
+    case Achievement:               return "Achievement";
+    case ChallengeComplete:         return "Challenge Complete";
+    case ChallengeFailed:           return "Challenge Failed";
+    case TakeoverVictory:           return "Takeover Victory!";
+    case TakeoverDefeat:            return "Takeover Defeat";
+    case TreasuryProgress:          return "Treasury Progress";
+    case TreasuryFull:              return "Treasury Full";
+    case WarchestProgress:          return "Warchest Progress";
+    case WarchestFull:              return "Warchest Full";
+    case FactionLevelUp:            return "Faction Level Up";
+    case FactionLevelDown:          return "Faction Level Down";
+    case FactionDiscovered:         return "Faction Discovered";
+    case FactionWarning:            return "Faction Warning";
+    case DiplomacyUpdated:          return "Diplomacy Updated";
+    case StrikeHit:                 return "Strike Hit";
+    case StrikeDefeat:              return "Strike Defeat";
+    case SurgeWarmUpEnded:          return "Surge Started";
+    case SurgeHostileGroupDefeated: return "Surge Hostiles Defeated";
+    case SurgeTimeLeft:             return "Surge Time Warning";
+    case ArenaTimeLeft:             return "Arena Time Warning";
+    case FleetPresetApplied:        return "Fleet Preset Applied";
+    default:                        return nullptr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform notification delivery
+// ---------------------------------------------------------------------------
+#if _WIN32
+static void show_system_notification(const char* title, const char* body)
+{
+  try {
+    using namespace winrt::Windows::UI::Notifications;
+    using namespace winrt::Windows::Data::Xml::Dom;
+
+    auto xml   = ToastNotificationManager::GetTemplateContent(ToastTemplateType::ToastText02);
+    auto nodes = xml.GetElementsByTagName(L"text");
+    nodes.Item(0).InnerText(winrt::to_hstring(title));
+    nodes.Item(1).InnerText(winrt::to_hstring(body));
+
+    auto notification = ToastNotification(xml);
+    auto notifier     = ToastNotificationManager::CreateToastNotifier(L"Star Trek Fleet Command");
+    notifier.Show(notification);
+  } catch (const winrt::hresult_error& e) {
+    spdlog::warn("[Notify] WinRT notification failed: {}", winrt::to_string(e.message()));
+  } catch (...) {
+    spdlog::warn("[Notify] WinRT notification failed (unknown error)");
+  }
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// Resolve basic localized text from a Toast's TextLocaleTextContext
+// ---------------------------------------------------------------------------
+static std::string resolve_toast_text(Toast* toast)
+{
+  if (!s_localize_ltc) return {};
+
+  auto* ltc = toast->get_TextLocaleTextContext();
+  if (!ltc) return {};
+
+  auto* langMgr = LanguageManager::Instance();
+  if (!langMgr) return {};
+
+  Il2CppString*  resolved = nullptr;
+  void*          params[2] = { &resolved, ltc };
+  Il2CppException* exc = nullptr;
+  il2cpp_runtime_invoke(s_localize_ltc, langMgr, params, &exc);
+
+  if (exc || !resolved) return {};
+  return to_string(resolved);
+}
+
+// ---------------------------------------------------------------------------
+// Strip Unity rich text tags (e.g. <color=#FF0000>, <b>, </size>)
+// ---------------------------------------------------------------------------
+static std::string strip_unity_rich_text(const std::string& s)
+{
+  std::string result;
+  result.reserve(s.size());
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '<') {
+      auto end = s.find('>', i);
+      if (end != std::string::npos) { i = end + 1; continue; }
+    }
+    result += s[i++];
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void notification_init()
+{
+  // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
+  // 2-parameter overload that takes an LTC and returns a localized string.
+  auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
+  if (lm_helper.isValidHelper()) {
+    auto* cls = lm_helper.get_cls();
+    if (cls) {
+      void* iter = nullptr;
+      while (auto* method = il2cpp_class_get_methods(cls, &iter)) {
+        auto name = std::string_view(il2cpp_method_get_name(method));
+        auto pc   = il2cpp_method_get_param_count(method);
+        if (name == "Localize" && pc == 2) {
+          s_localize_ltc = method;
+          spdlog::info("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
+          break;
+        }
+      }
+    }
+  }
+
+  if (!s_localize_ltc) {
+    spdlog::warn("[Notify] Could not resolve LanguageManager::Localize — notifications will show titles only");
+  }
+
+#if _WIN32
+  try { winrt::init_apartment(); } catch (...) {}
+  spdlog::info("[Notify] Windows notification service initialized");
+#else
+  spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+}
+
+void notification_handle_toast(Toast* toast)
+{
+#if !_WIN32
+  return; // No notification delivery on non-Windows platforms yet
+#else
+  auto state = toast->get_State();
+
+  // Check if this toast type is in the user's notify list
+  const auto& notify_types = Config::Get().notify_banner_types;
+  if (std::ranges::find(notify_types, state) == notify_types.end()) {
+    return;
+  }
+
+  auto* title = toast_state_title(state);
+  if (!title) {
+    spdlog::debug("[Notify] No title mapping for toast state {}, skipping", state);
+    return;
+  }
+
+  auto body = strip_unity_rich_text(resolve_toast_text(toast));
+  if (body.empty()) {
+    body = "(no details available)";
+  }
+
+  spdlog::info("[Notify] {} — {}", title, body);
+  show_system_notification(title, body.c_str());
+#endif
+}

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -161,7 +161,7 @@ void notification_init()
         auto pc   = il2cpp_method_get_param_count(method);
         if (name == "Localize" && pc == 2) {
           s_localize_ltc = method;
-          spdlog::info("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
+          spdlog::debug("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
           break;
         }
       }
@@ -174,9 +174,9 @@ void notification_init()
 
 #if _WIN32
   try { winrt::init_apartment(); } catch (...) {}
-  spdlog::info("[Notify] Windows notification service initialized");
+  spdlog::debug("[Notify] Windows notification service initialized");
 #else
-  spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+  spdlog::debug("[Notify] Notification service: platform not supported (no-op)");
 #endif
 
   s_notification_initialized = true;
@@ -216,7 +216,7 @@ void notification_handle_toast(Toast* toast)
     body = "(no details available)";
   }
 
-  spdlog::info("[Notify] {} — {}", title, body);
+  spdlog::debug("[Notify] {} — {}", title, body);
   show_system_notification(title, body.c_str());
 #endif
 }

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -10,7 +10,6 @@
 
 #include <spdlog/spdlog.h>
 
-#include <algorithm>
 #include <string>
 
 #if _WIN32

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,4 +1,5 @@
 #include "patches/notification_service.h"
+#include "patches/battle_notify_parser.h"
 
 #include "config.h"
 #include "str_utils.h"
@@ -194,7 +195,10 @@ void notification_handle_toast(Toast* toast)
     return;
   }
 
-  auto body = strip_unity_rich_text(resolve_toast_text(toast));
+  auto body = battle_notify_parse(toast);
+  if (body.empty()) {
+    body = strip_unity_rich_text(resolve_toast_text(toast));
+  }
   if (body.empty()) {
     body = "(no details available)";
   }

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -22,6 +22,7 @@
 // IL2CPP method cache
 // ---------------------------------------------------------------------------
 static const MethodInfo* s_localize_ltc = nullptr;
+static bool              s_notification_initialized = false;
 
 // ---------------------------------------------------------------------------
 // Toast state → human-readable title
@@ -144,6 +145,10 @@ static std::string strip_unity_rich_text(const std::string& s)
 
 void notification_init()
 {
+  if (s_notification_initialized) {
+    return;
+  }
+
   // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
   // 2-parameter overload that takes an LTC and returns a localized string.
   auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
@@ -172,6 +177,15 @@ void notification_init()
   spdlog::info("[Notify] Windows notification service initialized");
 #else
   spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+
+  s_notification_initialized = true;
+}
+
+void notification_show(const char* title, const char* body)
+{
+#if _WIN32
+  show_system_notification(title, body);
 #endif
 }
 

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -1,0 +1,10 @@
+#pragma once
+
+struct Toast;
+
+// Initialize the notification service (resolve IL2CPP methods, init platform).
+// Call once during InstallToastBannerHooks().
+void notification_init();
+
+// Called from toast hooks — checks config, formats, and delivers notification.
+void notification_handle_toast(Toast* toast);

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -8,3 +8,13 @@ void notification_init();
 
 // Called from toast hooks — checks config, formats, and delivers notification.
 void notification_handle_toast(Toast* toast);
+
+/**
+ * @brief Send an arbitrary OS-native notification with the given title and body.
+ *
+ * Requires notification_init() to have been called first. No-op on non-Windows.
+ *
+ * @param title Notification title text.
+ * @param body  Notification body text.
+ */
+void notification_show(const char* title, const char* body);

--- a/mods/src/patches/parts/disable_banners.cc
+++ b/mods/src/patches/parts/disable_banners.cc
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "errormsg.h"
+#include "patches/notification_service.h"
 
 #include <il2cpp/il2cpp_helper.h>
 #include <prime/Toast.h>
@@ -11,6 +12,8 @@ struct ToastObserver {
 
 void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast *toast)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -21,6 +24,8 @@ void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast 
 
 void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_this, Toast *toast, uintptr_t cmpAction)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -31,6 +36,8 @@ void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_thi
 
 void InstallToastBannerHooks()
 {
+  notification_init();
+
   if (auto helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "ToastObserver");
       !helper.isValidHelper()) {
     ErrorMsg::MissingHelper("HUD", "ToastObserver");

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -22,25 +22,6 @@
 
 static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
 
-static const char* fleet_bar_state_str(FleetState state)
-{
-  switch (state) {
-    case FleetState::Unknown:      return "Unknown";
-    case FleetState::IdleInSpace:  return "IdleInSpace";
-    case FleetState::Docked:       return "Docked";
-    case FleetState::Mining:       return "Mining";
-    case FleetState::Destroyed:    return "Destroyed";
-    case FleetState::TieringUp:    return "TieringUp";
-    case FleetState::Repairing:    return "Repairing";
-    case FleetState::Battling:     return "Battling";
-    case FleetState::WarpCharging: return "WarpCharging";
-    case FleetState::Warping:      return "Warping";
-    case FleetState::Impulsing:    return "Impulsing";
-    case FleetState::Capturing:    return "Capturing";
-    default:                       return "Composite";
-  }
-}
-
 static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
 {
   auto* hull = fleet ? fleet->Hull : nullptr;
@@ -86,10 +67,6 @@ static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::strin
     spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
     return;
   }
-
-  if (oldState == FleetState::Warping && newState == FleetState::Docked) {
-    spdlog::info("[FleetBar] DOCKED_AFTER_WARP id={} ship='{}'", fleetId, shipName);
-  }
 }
 
 static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
@@ -101,14 +78,7 @@ static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
     auto shipName     = fleet_bar_ship_name(fleet);
 
     auto it = s_fleet_bar_states.find(fleetId);
-    if (it == s_fleet_bar_states.end()) {
-      spdlog::info("[FleetBar] SetWidgetData snapshot id={} ship='{}' state={}({})",
-                   fleetId, shipName, fleet_bar_state_str(currentState), (int)currentState);
-    } else if (it->second != currentState) {
-      spdlog::info("[FleetBar] SetWidgetData state id={} ship='{}' {}({}) -> {}({})",
-                   fleetId, shipName,
-                   fleet_bar_state_str(it->second), (int)it->second,
-                   fleet_bar_state_str(currentState), (int)currentState);
+    if (it != s_fleet_bar_states.end() && it->second != currentState) {
       maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
     }
 

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -58,13 +58,8 @@ static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::strin
 {
   if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
     auto body = "Your " + shipName + " has arrived in-system";
-    spdlog::info("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
+    spdlog::debug("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
     notification_show("Fleet Arrived", body.c_str());
-    return;
-  }
-
-  if (oldState == FleetState::Impulsing && newState == FleetState::IdleInSpace) {
-    spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
     return;
   }
 }

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -1,0 +1,138 @@
+/**
+ * @file fleet_arrival.cc
+ * @brief Fleet arrival detection driven by the bottom fleet bar state widgets.
+ *
+ * Hooks FleetStateWidget::SetWidgetData and watches FleetPlayerData state
+ * transitions. The most useful arrival signal is Warping -> Impulsing, which
+ * means the ship has dropped out of warp and entered the destination system.
+ */
+#include "errormsg.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <spud/detour.h>
+
+#include <patches/notification_service.h>
+#include <prime/FleetPlayerData.h>
+
+#include <spdlog/spdlog.h>
+#include <str_utils.h>
+
+#include <string_view>
+#include <unordered_map>
+
+static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
+
+static const char* fleet_bar_state_str(FleetState state)
+{
+  switch (state) {
+    case FleetState::Unknown:      return "Unknown";
+    case FleetState::IdleInSpace:  return "IdleInSpace";
+    case FleetState::Docked:       return "Docked";
+    case FleetState::Mining:       return "Mining";
+    case FleetState::Destroyed:    return "Destroyed";
+    case FleetState::TieringUp:    return "TieringUp";
+    case FleetState::Repairing:    return "Repairing";
+    case FleetState::Battling:     return "Battling";
+    case FleetState::WarpCharging: return "WarpCharging";
+    case FleetState::Warping:      return "Warping";
+    case FleetState::Impulsing:    return "Impulsing";
+    case FleetState::Capturing:    return "Capturing";
+    default:                       return "Composite";
+  }
+}
+
+static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
+{
+  auto* hull = fleet ? fleet->Hull : nullptr;
+  auto  name = (hull && hull->Name) ? to_string(hull->Name) : std::string{"?"};
+
+  constexpr std::string_view live_suffix = "_LIVE";
+  if (name.size() >= live_suffix.size() &&
+      name.compare(name.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
+    name.erase(name.size() - live_suffix.size());
+  }
+
+  for (auto& ch : name) {
+    if (ch == '_') {
+      ch = ' ';
+    }
+  }
+
+  return name;
+}
+
+static FleetPlayerData* fleet_bar_widget_context(void* self)
+{
+  if (!self) {
+    return nullptr;
+  }
+
+  auto helper      = IL2CppClassHelper{((Il2CppObject*)self)->klass};
+  auto get_context = helper.GetMethod<FleetPlayerData*(void*)>("get_Context", 0);
+  return get_context ? get_context(self) : nullptr;
+}
+
+static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName,
+                                              FleetState oldState, FleetState newState)
+{
+  if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
+    auto body = "Your " + shipName + " has arrived in-system";
+    spdlog::info("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
+    notification_show("Fleet Arrived", body.c_str());
+    return;
+  }
+
+  if (oldState == FleetState::Impulsing && newState == FleetState::IdleInSpace) {
+    spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
+    return;
+  }
+
+  if (oldState == FleetState::Warping && newState == FleetState::Docked) {
+    spdlog::info("[FleetBar] DOCKED_AFTER_WARP id={} ship='{}'", fleetId, shipName);
+  }
+}
+
+static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
+{
+  auto* fleet = fleet_bar_widget_context(self);
+  if (fleet) {
+    auto fleetId      = fleet->Id;
+    auto currentState = fleet->CurrentState;
+    auto shipName     = fleet_bar_ship_name(fleet);
+
+    auto it = s_fleet_bar_states.find(fleetId);
+    if (it == s_fleet_bar_states.end()) {
+      spdlog::info("[FleetBar] SetWidgetData snapshot id={} ship='{}' state={}({})",
+                   fleetId, shipName, fleet_bar_state_str(currentState), (int)currentState);
+    } else if (it->second != currentState) {
+      spdlog::info("[FleetBar] SetWidgetData state id={} ship='{}' {}({}) -> {}({})",
+                   fleetId, shipName,
+                   fleet_bar_state_str(it->second), (int)it->second,
+                   fleet_bar_state_str(currentState), (int)currentState);
+      maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
+    }
+
+    s_fleet_bar_states[fleetId] = currentState;
+  }
+
+  original(self);
+}
+
+void InstallFleetArrivalHooks()
+{
+  notification_init();
+
+  auto fleet_state_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget");
+  if (!fleet_state_widget.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Prime.HUD", "FleetStateWidget");
+    return;
+  }
+
+  auto set_widget_data = fleet_state_widget.GetMethod("SetWidgetData");
+  if (set_widget_data == nullptr) {
+    ErrorMsg::MissingMethod("FleetStateWidget", "SetWidgetData");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(set_widget_data, FleetStateWidget_SetWidgetData_Hook);
+}

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -35,6 +35,7 @@ void InstallResolutionListFix();
 void InstallTempCrashFixes();
 void InstallSyncPatches();
 void InstallObjectTrackers();
+void InstallFleetArrivalHooks();
 
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
 {
@@ -117,6 +118,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"ResolutionListFix", {InstallResolutionListFix, &cfg.installResolutionListFix}},
       {"SyncPatches", {InstallSyncPatches, &cfg.installSyncPatches}},
       {"ObjectTracker", {InstallObjectTrackers, &cfg.installObjectTracker}},
+        {"FleetArrival", {InstallFleetArrivalHooks, &cfg.installFleetArrivalHooks}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);
 

--- a/mods/src/prime/BattleResultHeader.h
+++ b/mods/src/prime/BattleResultHeader.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+enum class BattleType {
+  Fleet                          = 0,
+  Base                           = 1,
+  PassiveMarauder                = 2,
+  NpcInstantiated                = 3,
+  DockingPoint                   = 4,
+  ActiveMarauder_MarauderInit    = 5,
+  ActiveMarauder_PlayerInit      = 6,
+  ArmadaBase                     = 7,
+  ArmadaMarauder                 = 8,
+  PveDockingPoint                = 9,
+  ArmadaAsb                      = 10,
+  ArmadaMta                      = 11,
+  Hazard                         = 12,
+  PveCuttingBeam                 = 13,
+  PvpCuttingBeam                 = 14,
+  PveChainShot                   = 15,
+  PvpChainShot                   = 16
+};
+
+enum class BattleResultType {
+  Defeat         = 0,
+  Victory        = 1,
+  PartialVictory = 2
+};
+
+enum class FleetDataType {
+  DeployedFleet = 0,
+  Starbase      = 1,
+  Armada        = 2
+};
+
+struct BattleResultHeader {
+public:
+  __declspec(property(get = __get_PlayerShipHullId)) long PlayerShipHullId;
+  __declspec(property(get = __get_EnemyShipHullId)) long EnemyShipHullId;
+
+  Il2CppObject* get_PlayerUserProfile()
+  {
+    static auto prop = get_class_helper().GetProperty("PlayerUserProfile");
+    return prop.GetRaw<Il2CppObject>(this);
+  }
+
+  Il2CppObject* get_EnemyUserProfile()
+  {
+    static auto prop = get_class_helper().GetProperty("EnemyUserProfile");
+    return prop.GetRaw<Il2CppObject>(this);
+  }
+
+  Il2CppObject* get_SpecService()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x18);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "BattleResultHeader");
+    return class_helper;
+  }
+
+public:
+  long __get_PlayerShipHullId()
+  {
+    static auto prop = get_class_helper().GetProperty("PlayerShipHullId");
+    return *prop.Get<long>(this);
+  }
+
+  long __get_EnemyShipHullId()
+  {
+    static auto prop = get_class_helper().GetProperty("EnemyShipHullId");
+    return *prop.Get<long>(this);
+  }
+};

--- a/mods/src/prime/HullSpec.h
+++ b/mods/src/prime/HullSpec.h
@@ -15,6 +15,7 @@ enum class HullType {
 struct HullSpec {
 public:
   __declspec(property(get = __get_Id)) long Id;
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
   __declspec(property(get = __get_Type)) HullType Type;
 
 private:
@@ -32,9 +33,15 @@ public:
     return *(long*)((char*)this + field);
   }
 
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+
   HullType __get_Type()
   {
-    static auto field = get_class_helper().GetProperty("Type");
-    return *field.Get<HullType>(this);
+    static auto prop = get_class_helper().GetProperty("Type");
+    return *prop.Get<HullType>(this);
   }
 };

--- a/mods/src/prime/SpecService.h
+++ b/mods/src/prime/SpecService.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+#include "HullSpec.h"
+
+struct SpecService {
+public:
+  HullSpec* GetHull(long hullId)
+  {
+    static auto method =
+        get_class_helper().GetMethod<HullSpec*(SpecService*, long)>("GetHull");
+    return method(this, hullId);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Services", "SpecService");
+    return class_helper;
+  }
+};

--- a/mods/src/prime/Toast.h
+++ b/mods/src/prime/Toast.h
@@ -50,6 +50,16 @@ enum ToastState {
 
 struct Toast {
 public:
+  void* get_TextLocaleTextContext()
+  {
+    return *reinterpret_cast<void**>(reinterpret_cast<char*>(this) + 0x20);
+  }
+
+  Il2CppObject* get_Data()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x38);
+  }
+
   int get_State()
   {
     static auto prop = get_class_helper().GetProperty("State");

--- a/mods/src/prime/UserProfile.h
+++ b/mods/src/prime/UserProfile.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct UserProfile {
+public:
+  __declspec(property(get = __get_LocaId)) long LocaId;
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "UserProfile");
+    return class_helper;
+  }
+
+public:
+  long __get_LocaId()
+  {
+    static auto field = get_class_helper().GetField("_locaId").offset();
+    return *(long*)((char*)this + field);
+  }
+
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+};


### PR DESCRIPTION
## Summary

Adds a platform-abstracted notification service that delivers OS-level (Windows toast) notifications for configurable in-game event types. Defaults to **off** — no user-visible behavior change unless `notify_banner_types` is set.

---

## Implementation

### Notification Service (`notification_service.h/.cc`)

- WinRT-based toast delivery (zero third-party deps — no WinToastLib)
- Hard `#if _WIN32` guard: non-Windows platforms are compile-time no-ops
- `notification_init()` — idempotent init, safe to call from any hook installer
- `notification_show(title, body)` — fire-and-forget WinRT toast
- `notification_handle_toast(toast)` — called from existing `EnqueueToast`/`EnqueueOrCombineToast` hooks; resolves the toast's `LTC` text via `LanguageManager::Localize` before deciding whether to notify

### Config

```toml
[ui]
# Comma-separated list using the same type names as disabled_banner_types.
# Empty string = no notifications (default).
notify_banner_types = ""
```

### Battle Result Parser (`battle_notify_parser.cc/h`)

Extracts player/enemy names and ship hull classes from `BattleResultHeader` for battle toast types (`Victory`, `Defeat`, `PartialVictory`, `Station*`, `FleetBattle`, `Armada*`, `Assault*`). All IL2CPP property accesses wrapped in SEH guards for crash safety.

Format: `Guffawaffle (Newton) vs Assimilated Coryn-class`

- NPC profiles have empty display names — hull class name used as identifier instead of `NPC#<locaId>`
- Non-battle toasts fall back to the LTC text resolver

New prime headers: `BattleResultHeader.h`, `UserProfile.h`, `SpecService.h`

### Fleet Arrival Detection (`parts/fleet_arrival.cc`)

Hooks `FleetStateWidget::SetWidgetData` and watches `FleetPlayerData` state transitions. Fires a notification on `Warping → Impulsing` (ship dropped out of warp into destination system).

Uses `SPUD_STATIC_DETOUR` — no MinHook dependency.

---

## Notes

- All notification calls pass through the existing toast hook path (`disable_banners.cc`) — notification delivery is checked *before* the banner-disable filter, so players can receive an OS notification even for banners they've suppressed in-game
- The `notify_banner_types` config uses the same type names as `disabled_banner_types`, so power users can mirror their suppressed banners as OS toasts
- `fleetarrivalhooks` toggle added to `defaultconfig.h` for debug-build gating