### PR TITLE
Reference: configurable OS notifications and fleet alerts

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -125,6 +125,81 @@ system_zoom_preset_4 = 2750.0
 system_zoom_preset_5 = 5000.0
 zoom = 5000.0
 
+#  <[=============================================]>
+#
+#       *   *         *    *               ***
+#       **  *   ***  ***         *   ***   *
+#       * * *  *   *  *    *    **  *   *  ****
+#       *  **  *   *  *    *    *   *****    *
+#       *   *   ***    **  *   *     ***   ****
+#
+#  <[=============================================]>
+
+[notifications]
+# Master switch — must be true for any system notifications to fire.
+# When false, the individual notification toggles below are ignored.
+notifications_enabled = false
+
+# Supported: Battle notifications (fully parsed with player/ship detail)
+# Each type must be individually enabled
+notifications_victory = true
+notifications_defeat = true
+notifications_partial_victory = true
+notifications_station_victory = false
+notifications_station_defeat = false
+notifications_station_battle = false
+notifications_incoming_attack = false
+notifications_fleet_battle = false
+notifications_armada_battle_won = false
+notifications_armada_battle_lost = false
+notifications_assault_victory = false
+notifications_assault_defeat = false
+
+# Supported: Armada notifications (parsed with alliance/owner detail)
+notifications_armada_created = true
+notifications_armada_canceled = true
+
+# Supported: Event notifications (best-effort text resolution)
+# These may still show raw placeholders depending on the game's toast payload.
+notifications_tournament = true
+notifications_chained_event_scored = true
+
+# Supported: Fleet notifications (fleet-bar transitions and mining depletion)
+notifications_fleet_arrived_in_system = false
+notifications_fleet_started_mining = false
+notifications_fleet_node_depleted = false
+notifications_fleet_docked = false
+
+# Experimental — these use generic text resolution and may show raw placeholders
+# Enable individual types at your own risk
+notifications_standard = false
+notifications_faction_warning = false
+notifications_faction_level_up = false
+notifications_faction_level_down = false
+notifications_faction_discovered = false
+notifications_incoming_attack_faction = false
+notifications_armada_incoming_attack = false
+notifications_diplomacy_updated = false
+notifications_joined_takeover = false
+notifications_competitor_joined_takeover = false
+notifications_abandoned_territory = false
+notifications_takeover_victory = false
+notifications_takeover_defeat = false
+notifications_treasury_progress = false
+notifications_treasury_full = false
+notifications_achievement = false
+notifications_challenge_complete = false
+notifications_challenge_failed = false
+notifications_strike_hit = false
+notifications_strike_defeat = false
+notifications_warchest_progress = false
+notifications_warchest_full = false
+notifications_arena_time_left = false
+notifications_fleet_preset_applied = false
+notifications_surge_warmup_ended = false
+notifications_surge_hostile_group_defeated = false
+notifications_surge_time_left = false
+
 #  <[=====================================================]>
 #
 #       ****           *            *
@@ -324,11 +399,9 @@ disable_toast_banners = false
 
 disabled_banner_types = ""
 
-# System notifications for in-game events. Comma-separated list of toast types
-# to deliver as OS-level notifications (Windows toast). Uses the same type names
-# as disabled_banner_types. Empty string = no notifications.
-# Example: "Victory, Defeat, IncomingAttack, StationBattle"
-notify_banner_types = ""
+# OS notification selection now lives under [notifications].
+# Legacy [ui].notify_on_banner_types / notify_banner_types keys are still
+# accepted for migration from older configs, but they are not documented here.
 
 # Subgroup: Chat
 # --------------

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -169,6 +169,7 @@ notifications_fleet_arrived_in_system = false
 notifications_fleet_started_mining = false
 notifications_fleet_node_depleted = false
 notifications_fleet_docked = false
+notifications_fleet_repair_complete = false
 
 # Experimental — these use generic text resolution and may show raw placeholders
 # Enable individual types at your own risk

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -324,6 +324,12 @@ disable_toast_banners = false
 
 disabled_banner_types = ""
 
+# System notifications for in-game events. Comma-separated list of toast types
+# to deliver as OS-level notifications (Windows toast). Uses the same type names
+# as disabled_banner_types. Empty string = no notifications.
+# Example: "Victory, Defeat, IncomingAttack, StationBattle"
+notify_banner_types = ""
+
 # Subgroup: Chat
 # --------------
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -689,6 +689,29 @@ void Config::Load()
 
   parsed["ui"].as_table()->insert_or_assign("disabled_banner_types", bannerString);
 
+  // Parse notify_banner_types using the same bannerTypes lookup table
+  auto notify_banner_types_str =
+      get_config_or_default<std::string>(config, parsed, "ui", "notify_banner_types", DCU::notify_banner_types, write_log);
+
+  std::vector<std::string> notify_types = StrSplit(notify_banner_types_str, ',');
+  std::string              notifyString;
+
+  for (const auto& [key, value] : bannerTypes) {
+    auto upper_key = AsciiStrToUpper(key);
+    for (const std::string_view _type : notify_types) {
+      auto stripped_type = StripLeadingAsciiWhitespace(_type);
+      auto upper_type    = AsciiStrToUpper(stripped_type);
+      if (upper_key == upper_type) {
+        this->notify_banner_types.emplace_back(value);
+        if (!notifyString.empty()) notifyString.append(", ");
+        notifyString.append(key);
+      }
+    }
+  }
+
+  spdlog::debug("Final notify banner types: {}", notifyString);
+  parsed["ui"].as_table()->insert_or_assign("notify_banner_types", notifyString);
+
   spdlog::debug("");
 
   //if (this->enable_experimental) {

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -496,6 +496,7 @@ void Config::Load()
   this->installResolutionListFix = get_config_or_default(config, parsed, "patches", "resolutionlistfix", DCP::resolutionlistfix, write_config);
   this->installSyncPatches       = get_config_or_default(config, parsed, "patches", "syncpatches", DCP::syncpatches, write_config);
   this->installObjectTracker     = get_config_or_default(config, parsed, "patches", "objecttracker", DCP::objecttracker, write_config);
+  this->installFleetArrivalHooks = get_config_or_default(config, parsed, "patches", "fleetarrivalhooks", DCP::fleetarrivalhooks, write_config);
   spdlog::debug("");
 #else
   this->installUiScaleHooks               = true;
@@ -513,6 +514,7 @@ void Config::Load()
   this->installResolutionListFix          = true;
   this->installSyncPatches                = true;
   this->installObjectTracker              = true;
+  this->installFleetArrivalHooks          = true;
 #endif
   
   this->queue_enabled       = get_config_or_default(config, parsed, "control", "queue_enabled", DCC::queue_enabled, write_config);

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -780,6 +780,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "notifications", "notifications_fleet_node_depleted", DCN::Fleet::node_depleted, write_config);
   this->notifications.fleet_docked =
       get_config_or_default(config, parsed, "notifications", "notifications_fleet_docked", DCN::Fleet::docked, write_config);
+    this->notifications.fleet_repair_complete = get_config_or_default(
+      config, parsed, "notifications", "notifications_fleet_repair_complete", DCN::Fleet::repair_complete, write_config);
 
   this->notifications.ClearToastStates();
   for (const auto& spec : notificationToggleSpecs) {

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -19,6 +19,7 @@
 
 namespace DCP = DefaultConfig::Patches;
 namespace DCG = DefaultConfig::Graphics;
+namespace DCN = DefaultConfig::Notifications;
 namespace DCC = DefaultConfig::Control;
 namespace DCU = DefaultConfig::UI;
 namespace DCBS = DefaultConfig::Buffs;
@@ -32,11 +33,16 @@ static const eastl::tuple<const char*, int> bannerTypes[] = {
     {"FactionLevelUp", ToastState::FactionLevelUp},
     {"FactionLevelDown", ToastState::FactionLevelDown},
     {"FactionDiscovered", ToastState::FactionDiscovered},
+  {"IncomingAttack", ToastState::IncomingAttack},
     {"IncomingAttackFaction", ToastState::IncomingAttackFaction},
     {"FleetBattle", ToastState::FleetBattle},
+  {"StationBattle", ToastState::StationBattle},
+  {"StationVictory", ToastState::StationVictory},
     {"Victory", ToastState::Victory},
     {"Defeat", ToastState::Defeat},
+  {"StationDefeat", ToastState::StationDefeat},
     {"Event", ToastState::Tournament},
+  {"Tournament", ToastState::Tournament},
     {"ArmadaCreated", ToastState::ArmadaCreated},
     {"ArmadaCanceled", ToastState::ArmadaCanceled},
     {"ArmadaIncomingAttack", ToastState::ArmadaIncomingAttack},
@@ -66,6 +72,58 @@ static const eastl::tuple<const char*, int> bannerTypes[] = {
     {"SurgeWarmUpEnded", ToastState::SurgeWarmUpEnded},
     {"SurgeHostileGroupDefeated", ToastState::SurgeHostileGroupDefeated},
     {"SurgeTimeLeft", ToastState::SurgeTimeLeft},
+};
+
+struct NotificationToggleSpec {
+  std::string_view key;
+  int              toast_state;
+  bool             default_value;
+};
+
+static constexpr NotificationToggleSpec notificationToggleSpecs[] = {
+    {"notifications_victory", Victory, DCN::Battle::victory},
+    {"notifications_defeat", Defeat, DCN::Battle::defeat},
+    {"notifications_partial_victory", PartialVictory, DCN::Battle::partial_victory},
+    {"notifications_station_victory", StationVictory, DCN::Battle::station_victory},
+    {"notifications_station_defeat", StationDefeat, DCN::Battle::station_defeat},
+    {"notifications_station_battle", StationBattle, DCN::Battle::station_battle},
+    {"notifications_incoming_attack", IncomingAttack, DCN::Battle::incoming_attack},
+    {"notifications_fleet_battle", FleetBattle, DCN::Battle::fleet_battle},
+    {"notifications_armada_battle_won", ArmadaBattleWon, DCN::Battle::armada_battle_won},
+    {"notifications_armada_battle_lost", ArmadaBattleLost, DCN::Battle::armada_battle_lost},
+    {"notifications_assault_victory", AssaultVictory, DCN::Battle::assault_victory},
+    {"notifications_assault_defeat", AssaultDefeat, DCN::Battle::assault_defeat},
+    {"notifications_armada_created", ArmadaCreated, DCN::Armada::created},
+    {"notifications_armada_canceled", ArmadaCanceled, DCN::Armada::canceled},
+    {"notifications_tournament", Tournament, DCN::Events::tournament},
+    {"notifications_chained_event_scored", ChainedEventScored, DCN::Events::chained_event_scored},
+    {"notifications_standard", Standard, DCN::Experimental::standard},
+    {"notifications_faction_warning", FactionWarning, DCN::Experimental::faction_warning},
+    {"notifications_faction_level_up", FactionLevelUp, DCN::Experimental::faction_level_up},
+    {"notifications_faction_level_down", FactionLevelDown, DCN::Experimental::faction_level_down},
+    {"notifications_faction_discovered", FactionDiscovered, DCN::Experimental::faction_discovered},
+    {"notifications_incoming_attack_faction", IncomingAttackFaction, DCN::Experimental::incoming_attack_faction},
+    {"notifications_armada_incoming_attack", ArmadaIncomingAttack, DCN::Experimental::armada_incoming_attack},
+    {"notifications_diplomacy_updated", DiplomacyUpdated, DCN::Experimental::diplomacy_updated},
+    {"notifications_joined_takeover", JoinedTakeover, DCN::Experimental::joined_takeover},
+    {"notifications_competitor_joined_takeover", CompetitorJoinedTakeover, DCN::Experimental::competitor_joined_takeover},
+    {"notifications_abandoned_territory", AbandonedTerritory, DCN::Experimental::abandoned_territory},
+    {"notifications_takeover_victory", TakeoverVictory, DCN::Experimental::takeover_victory},
+    {"notifications_takeover_defeat", TakeoverDefeat, DCN::Experimental::takeover_defeat},
+    {"notifications_treasury_progress", TreasuryProgress, DCN::Experimental::treasury_progress},
+    {"notifications_treasury_full", TreasuryFull, DCN::Experimental::treasury_full},
+    {"notifications_achievement", Achievement, DCN::Experimental::achievement},
+    {"notifications_challenge_complete", ChallengeComplete, DCN::Experimental::challenge_complete},
+    {"notifications_challenge_failed", ChallengeFailed, DCN::Experimental::challenge_failed},
+    {"notifications_strike_hit", StrikeHit, DCN::Experimental::strike_hit},
+    {"notifications_strike_defeat", StrikeDefeat, DCN::Experimental::strike_defeat},
+    {"notifications_warchest_progress", WarchestProgress, DCN::Experimental::warchest_progress},
+    {"notifications_warchest_full", WarchestFull, DCN::Experimental::warchest_full},
+    {"notifications_arena_time_left", ArenaTimeLeft, DCN::Experimental::arena_time_left},
+    {"notifications_fleet_preset_applied", FleetPresetApplied, DCN::Experimental::fleet_preset_applied},
+    {"notifications_surge_warmup_ended", SurgeWarmUpEnded, DCN::Experimental::surge_warmup_ended},
+    {"notifications_surge_hostile_group_defeated", SurgeHostileGroupDefeated, DCN::Experimental::surge_hostile_group_defeated},
+    {"notifications_surge_time_left", SurgeTimeLeft, DCN::Experimental::surge_time_left},
 };
 
 bool SyncConfig::enabled(SyncConfig::Type type) const
@@ -691,28 +749,73 @@ void Config::Load()
 
   parsed["ui"].as_table()->insert_or_assign("disabled_banner_types", bannerString);
 
-  // Parse notify_banner_types using the same bannerTypes lookup table
-  auto notify_banner_types_str =
-      get_config_or_default<std::string>(config, parsed, "ui", "notify_banner_types", DCU::notify_banner_types, write_log);
+  auto* notifications_table = config["notifications"].as_table();
+  const bool has_explicit_notification_toggles = notifications_table &&
+      std::ranges::any_of(notificationToggleSpecs, [notifications_table](const auto& spec) {
+        return notifications_table->contains(spec.key);
+      });
 
-  std::vector<std::string> notify_types = StrSplit(notify_banner_types_str, ',');
-  std::string              notifyString;
-
-  for (const auto& [key, value] : bannerTypes) {
-    auto upper_key = AsciiStrToUpper(key);
-    for (const std::string_view _type : notify_types) {
-      auto stripped_type = StripLeadingAsciiWhitespace(_type);
-      auto upper_type    = AsciiStrToUpper(stripped_type);
-      if (upper_key == upper_type) {
-        this->notify_banner_types.emplace_back(value);
-        if (!notifyString.empty()) notifyString.append(", ");
-        notifyString.append(key);
-      }
+  auto* ui_table = config["ui"].as_table();
+  std::string legacy_notify_banner_types;
+  bool        has_legacy_notify_banner_types = false;
+  if (ui_table) {
+    if (auto notify_on_value = config["ui"]["notify_on_banner_types"].value<std::string>(); notify_on_value.has_value()) {
+      legacy_notify_banner_types     = notify_on_value.value();
+      has_legacy_notify_banner_types = true;
+    } else if (auto notify_value = config["ui"]["notify_banner_types"].value<std::string>(); notify_value.has_value()) {
+      legacy_notify_banner_types     = notify_value.value();
+      has_legacy_notify_banner_types = true;
     }
   }
 
-  spdlog::debug("Final notify banner types: {}", notifyString);
-  parsed["ui"].as_table()->insert_or_assign("notify_banner_types", notifyString);
+  const bool use_legacy_notify_allowlist = has_legacy_notify_banner_types && !has_explicit_notification_toggles;
+
+  this->notifications.enabled =
+      get_config_or_default(config, parsed, "notifications", "notifications_enabled", DCN::enabled, write_config);
+  this->notifications.fleet_arrived_in_system = get_config_or_default(
+      config, parsed, "notifications", "notifications_fleet_arrived_in_system", DCN::Fleet::arrived_in_system, write_config);
+  this->notifications.fleet_started_mining =
+      get_config_or_default(config, parsed, "notifications", "notifications_fleet_started_mining", DCN::Fleet::started_mining, write_config);
+  this->notifications.fleet_node_depleted =
+      get_config_or_default(config, parsed, "notifications", "notifications_fleet_node_depleted", DCN::Fleet::node_depleted, write_config);
+  this->notifications.fleet_docked =
+      get_config_or_default(config, parsed, "notifications", "notifications_fleet_docked", DCN::Fleet::docked, write_config);
+
+  this->notifications.ClearToastStates();
+  for (const auto& spec : notificationToggleSpecs) {
+    const bool default_value = use_legacy_notify_allowlist ? false : spec.default_value;
+    const bool enabled = get_config_or_default(config, parsed, "notifications", spec.key, default_value, write_config);
+    this->notifications.SetToastStateEnabled(spec.toast_state, enabled);
+  }
+
+  if (use_legacy_notify_allowlist) {
+    if (!(notifications_table && notifications_table->contains("notifications_enabled"))) {
+      this->notifications.enabled = true;
+      parsed["notifications"].as_table()->insert_or_assign("notifications_enabled", true);
+    }
+
+    this->notifications.ClearToastStates();
+
+    std::vector<std::string> notify_types = StrSplit(legacy_notify_banner_types, ',');
+    for (const auto& [key, value] : bannerTypes) {
+      auto upper_key = AsciiStrToUpper(key);
+      for (const std::string_view raw_type : notify_types) {
+        auto stripped_type = StripLeadingAsciiWhitespace(raw_type);
+        auto upper_type    = AsciiStrToUpper(stripped_type);
+        if (upper_key == upper_type) {
+          this->notifications.SetToastStateEnabled(value, true);
+        }
+      }
+    }
+
+    for (const auto& spec : notificationToggleSpecs) {
+      parsed["notifications"].as_table()->insert_or_assign(spec.key, this->notifications.EnabledForToastState(spec.toast_state));
+    }
+
+    spdlog::warn("Deprecation Warning: [ui].notify_on_banner_types / [ui].notify_banner_types is deprecated. Migrate to [notifications].");
+  } else if (has_legacy_notify_banner_types) {
+    spdlog::warn("Ignoring deprecated [ui] notification allowlist because explicit [notifications] toggles are present.");
+  }
 
   spdlog::debug("");
 

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -160,6 +160,7 @@ public:
 
   bool             borderless_fullscreen;
   std::vector<int> disabled_banner_types;
+  std::vector<int> notify_banner_types;
 
   int  extend_donation_max;
   bool extend_donation_slider;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -203,6 +203,7 @@ public:
   bool installResolutionListFix;
   bool installSyncPatches;
   bool installObjectTracker;
+  bool installFleetArrivalHooks;
 
   std::string config_settings_url;
   std::string config_assets_url_override;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <bitset>
 #include <map>
 #include <string>
 #include <vector>
@@ -103,6 +104,44 @@ public:
   std::string token;
 };
 
+class NotificationConfig
+{
+public:
+  static constexpr size_t MaxToastStates = 64;
+
+  bool enabled                  = false;
+  bool fleet_arrived_in_system  = false;
+  bool fleet_started_mining     = false;
+  bool fleet_node_depleted      = false;
+  bool fleet_docked             = false;
+
+  [[nodiscard]] bool EnabledForToastState(int state) const
+  {
+    if (state < 0 || static_cast<size_t>(state) >= toast_state_enabled.size()) {
+      return false;
+    }
+
+    return toast_state_enabled.test(static_cast<size_t>(state));
+  }
+
+  void SetToastStateEnabled(int state, bool isEnabled)
+  {
+    if (state < 0 || static_cast<size_t>(state) >= toast_state_enabled.size()) {
+      return;
+    }
+
+    toast_state_enabled.set(static_cast<size_t>(state), isEnabled);
+  }
+
+  void ClearToastStates()
+  {
+    toast_state_enabled.reset();
+  }
+
+private:
+  std::bitset<MaxToastStates> toast_state_enabled{};
+};
+
 class Config final
 {
 public:
@@ -157,10 +196,10 @@ public:
   float system_zoom_preset_4;
   float system_zoom_preset_5;
   float transition_time;
+  NotificationConfig notifications;
 
   bool             borderless_fullscreen;
   std::vector<int> disabled_banner_types;
-  std::vector<int> notify_banner_types;
 
   int  extend_donation_max;
   bool extend_donation_slider;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -114,6 +114,7 @@ public:
   bool fleet_started_mining     = false;
   bool fleet_node_depleted      = false;
   bool fleet_docked             = false;
+  bool fleet_repair_complete    = false;
 
   [[nodiscard]] bool EnabledForToastState(int state) const
   {

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -48,23 +48,24 @@ namespace Graphics
 
 namespace Patches
 {
-  constexpr bool bufffixhooks               = true;
-  constexpr bool chatpatches                = true;
-  constexpr bool freeresizehooks            = true;
-  constexpr bool hotkeyhooks                = true;
-  constexpr bool improveresponsivenesshooks = true;
-  constexpr bool miscpatches                = true;
-  constexpr bool objecttracker              = true;
-  constexpr bool panhooks                   = true;
-  constexpr bool resolutionlistfix          = true;
-  constexpr bool syncpatches                = true;
-  constexpr bool tempcrashfixes             = true;
-  constexpr bool testpatches                = true;
-  constexpr bool toastbannerhooks           = true;
-  constexpr bool uiscalehooks               = true;
-  constexpr bool zoomhooks                  = true;
-} // namespace Patches
-
+  // Debug-build toggles for individual hook categories.
+  // In release builds these are ignored and all patches are force-enabled.
+  constexpr bool bufffixhooks               = true;  ///< Out-of-dock power / buff calculation fixes.
+  constexpr bool chatpatches                = true;  ///< Chat-related UI patches.
+  constexpr bool freeresizehooks            = true;  ///< Free window resize hooks.
+  constexpr bool hotkeyhooks                = true;  ///< Keyboard hotkey injection.
+  constexpr bool improveresponsivenesshooks = true;  ///< Input-responsiveness improvements.
+  constexpr bool miscpatches                = true;  ///< Misc one-off fixes.
+  constexpr bool objecttracker              = true;  ///< In-system object tracking overlay.
+  constexpr bool fleetarrivalhooks          = true;  ///< Fleet arrival detection from the bottom fleet bar.
+  constexpr bool panhooks                   = true;  ///< Pan-momentum hooks.
+  constexpr bool resolutionlistfix          = true;  ///< Resolution-list population fix.
+  constexpr bool syncpatches                = true;  ///< Data-sync network hooks.
+  constexpr bool tempcrashfixes             = true;  ///< Temporary crash mitigations.
+  constexpr bool testpatches                = true;  ///< Test / experimental patches.
+  constexpr bool toastbannerhooks           = true;  ///< Toast-banner filtering hooks.
+  constexpr bool uiscalehooks               = true;  ///< UI scale override hooks.
+  constexpr bool zoomhooks                  = true;  ///< Camera zoom override hooks.
 namespace Shortcuts
 {
   constexpr const char* toggle_queue          = "CTRL-Q";

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -196,6 +196,7 @@ namespace UI
   constexpr bool        disable_toast_banners       = false;
   constexpr bool        disable_veil_chat           = false;
   constexpr const char* disabled_banner_types       = "";
+  constexpr const char* notify_banner_types         = "";
   constexpr auto        extend_donation_max         = 80;
   constexpr bool        extend_donation_slider      = true;
   constexpr bool        show_armada_cargo           = true;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -46,6 +46,78 @@ namespace Graphics
   constexpr auto zoom                        = 5000;
 } // namespace Graphics
 
+namespace Notifications
+{
+  constexpr bool enabled = false;
+
+  namespace Battle
+  {
+    constexpr bool victory            = true;
+    constexpr bool defeat             = true;
+    constexpr bool partial_victory    = true;
+    constexpr bool station_victory    = false;
+    constexpr bool station_defeat     = false;
+    constexpr bool station_battle     = false;
+    constexpr bool incoming_attack    = false;
+    constexpr bool fleet_battle       = false;
+    constexpr bool armada_battle_won  = false;
+    constexpr bool armada_battle_lost = false;
+    constexpr bool assault_victory    = false;
+    constexpr bool assault_defeat     = false;
+  } // namespace Battle
+
+  namespace Armada
+  {
+    constexpr bool created  = true;
+    constexpr bool canceled = true;
+  } // namespace Armada
+
+  namespace Events
+  {
+    constexpr bool tournament           = true;
+    constexpr bool chained_event_scored = true;
+  } // namespace Events
+
+  namespace Experimental
+  {
+    constexpr bool standard                     = false;
+    constexpr bool faction_warning              = false;
+    constexpr bool faction_level_up             = false;
+    constexpr bool faction_level_down           = false;
+    constexpr bool faction_discovered           = false;
+    constexpr bool incoming_attack_faction      = false;
+    constexpr bool armada_incoming_attack       = false;
+    constexpr bool diplomacy_updated            = false;
+    constexpr bool joined_takeover              = false;
+    constexpr bool competitor_joined_takeover   = false;
+    constexpr bool abandoned_territory          = false;
+    constexpr bool takeover_victory             = false;
+    constexpr bool takeover_defeat              = false;
+    constexpr bool treasury_progress            = false;
+    constexpr bool treasury_full                = false;
+    constexpr bool achievement                  = false;
+    constexpr bool challenge_complete           = false;
+    constexpr bool challenge_failed             = false;
+    constexpr bool strike_hit                   = false;
+    constexpr bool strike_defeat                = false;
+    constexpr bool warchest_progress            = false;
+    constexpr bool warchest_full                = false;
+    constexpr bool arena_time_left              = false;
+    constexpr bool fleet_preset_applied         = false;
+    constexpr bool surge_warmup_ended           = false;
+    constexpr bool surge_hostile_group_defeated = false;
+    constexpr bool surge_time_left              = false;
+  } // namespace Experimental
+
+  namespace Fleet
+  {
+    constexpr bool arrived_in_system = false;
+    constexpr bool started_mining    = false;
+    constexpr bool node_depleted     = false;
+    constexpr bool docked            = false;
+  } // namespace Fleet
+} // namespace Notifications
+
 namespace Patches
 {
   // Debug-build toggles for individual hook categories.

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -66,6 +66,8 @@ namespace Patches
   constexpr bool toastbannerhooks           = true;  ///< Toast-banner filtering hooks.
   constexpr bool uiscalehooks               = true;  ///< UI scale override hooks.
   constexpr bool zoomhooks                  = true;  ///< Camera zoom override hooks.
+} // namespace Patches
+
 namespace Shortcuts
 {
   constexpr const char* toggle_queue          = "CTRL-Q";

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -115,6 +115,7 @@ namespace Notifications
     constexpr bool started_mining    = false;
     constexpr bool node_depleted     = false;
     constexpr bool docked            = false;
+    constexpr bool repair_complete   = false;
   } // namespace Fleet
 } // namespace Notifications
 

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -72,14 +72,14 @@ static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
   if (hullId == 0) return "";
 
   auto* specSvc = reinterpret_cast<SpecService*>(brh->get_SpecService());
-  if (specSvc) {
-    auto* hull = specSvc->GetHull(hullId);
-    if (hull) {
-      auto* nameStr = hull->Name;
-      auto nameKey  = nameStr ? to_string(nameStr) : std::string{};
-      if (!nameKey.empty()) return parse_hull_key(nameKey);
-    }
-  }
+  if (!specSvc) return fmt::format("Hull#{}", hullId);
+
+  auto* hull = specSvc->GetHull(hullId);
+  if (!hull) return fmt::format("Hull#{}", hullId);
+
+  auto* nameStr = hull->Name;
+  auto nameKey  = nameStr ? to_string(nameStr) : std::string{};
+  if (!nameKey.empty()) return parse_hull_key(nameKey);
 
   return fmt::format("Hull#{}", hullId);
 }
@@ -93,12 +93,15 @@ struct BattleSummaryData {
   std::string playerShip;
   std::string enemyShip;
 
+  /** @brief Format the summary as "Player (Ship) vs Enemy (Ship)".
+   *  For NPCs (empty name), uses the ship hull name as the identifier. */
   std::string format_body() const
   {
     auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
-      if (name.empty()) return "";
-      if (ship.empty()) return name;
-      return fmt::format("{} ({})", name, ship);
+      if (!name.empty() && !ship.empty()) return fmt::format("{} ({})", name, ship);
+      if (!name.empty()) return name;
+      if (!ship.empty()) return ship;
+      return "";
     };
 
     auto left  = format_side(playerName, playerShip);
@@ -126,10 +129,7 @@ static BattleSummaryData build_battle_data(Il2CppObject* data)
         if (profile) {
           auto* nameStr = profile->Name;
           if (nameStr) result.playerName = to_string(nameStr);
-          if (result.playerName.empty()) {
-            auto locaId = profile->LocaId;
-            if (locaId > 0) result.playerName = fmt::format("NPC#{}", locaId);
-          }
+          // NPC profiles have empty names — leave blank, hull name used instead
         }
       }))
     spdlog::warn("[Notify] SEH: get_PlayerUserProfile crashed");
@@ -140,10 +140,7 @@ static BattleSummaryData build_battle_data(Il2CppObject* data)
         if (profile) {
           auto* nameStr = profile->Name;
           if (nameStr) result.enemyName = to_string(nameStr);
-          if (result.enemyName.empty()) {
-            auto locaId = profile->LocaId;
-            if (locaId > 0) result.enemyName = fmt::format("NPC#{}", locaId);
-          }
+          // NPC profiles have empty names — leave blank, hull name used instead
         }
       }))
     spdlog::warn("[Notify] SEH: get_EnemyUserProfile crashed");

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -1,0 +1,198 @@
+#include "patches/battle_notify_parser.h"
+
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/BattleResultHeader.h>
+#include <prime/HullSpec.h>
+#include <prime/SpecService.h>
+#include <prime/Toast.h>
+#include <prime/UserProfile.h>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// SEH wrapper — catches access violations from bad IL2CPP pointers
+// ---------------------------------------------------------------------------
+template <typename Fn>
+static bool seh_call(Fn fn)
+{
+#if _WIN32
+  __try {
+    fn();
+    return true;
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return false;
+  }
+#else
+  fn();
+  return true;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Hull name key → human-readable name
+//   "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
+// ---------------------------------------------------------------------------
+static std::string parse_hull_key(const std::string& key)
+{
+  auto s = key;
+
+  if (s.size() > 5 && s.ends_with("_LIVE"))
+    s = s.substr(0, s.size() - 5);
+
+  if (s.starts_with("Hull_"))
+    s = s.substr(5);
+
+  for (auto& c : s)
+    if (c == '_') c = ' ';
+
+  if (s.size() >= 2 && s[0] == 'L' && std::isdigit(s[1])) {
+    auto space = s.find(' ');
+    auto lvl   = s.substr(1, space == std::string::npos ? std::string::npos : space - 1);
+    auto rest  = space == std::string::npos ? "" : s.substr(space);
+    s = "Lv." + lvl + rest;
+  }
+
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Resolve hull ID → display name via SpecService
+// ---------------------------------------------------------------------------
+static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
+{
+  if (hullId == 0) return "";
+
+  auto* specSvc = reinterpret_cast<SpecService*>(brh->get_SpecService());
+  if (specSvc) {
+    auto* hull = specSvc->GetHull(hullId);
+    if (hull) {
+      auto* nameStr = hull->Name;
+      auto nameKey  = nameStr ? to_string(nameStr) : std::string{};
+      if (!nameKey.empty()) return parse_hull_key(nameKey);
+    }
+  }
+
+  return fmt::format("Hull#{}", hullId);
+}
+
+// ---------------------------------------------------------------------------
+// Format "Name (Ship) vs Name (Ship)"
+// ---------------------------------------------------------------------------
+struct BattleSummaryData {
+  std::string playerName;
+  std::string enemyName;
+  std::string playerShip;
+  std::string enemyShip;
+
+  std::string format_body() const
+  {
+    auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
+      if (name.empty()) return "";
+      if (ship.empty()) return name;
+      return fmt::format("{} ({})", name, ship);
+    };
+
+    auto left  = format_side(playerName, playerShip);
+    auto right = format_side(enemyName, enemyShip);
+    if (left.empty() && right.empty()) return "";
+    if (left.empty()) return right;
+    if (right.empty()) return left;
+    return left + " vs " + right;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Extract player/enemy names + ship hulls from BattleResultHeader
+// ---------------------------------------------------------------------------
+static BattleSummaryData build_battle_data(Il2CppObject* data)
+{
+  BattleSummaryData result;
+  if (!data) return result;
+
+  auto* brh = reinterpret_cast<BattleResultHeader*>(data);
+
+  if (!seh_call([&] {
+        auto* p       = brh->get_PlayerUserProfile();
+        auto* profile = reinterpret_cast<UserProfile*>(p);
+        if (profile) {
+          auto* nameStr = profile->Name;
+          if (nameStr) result.playerName = to_string(nameStr);
+          if (result.playerName.empty()) {
+            auto locaId = profile->LocaId;
+            if (locaId > 0) result.playerName = fmt::format("NPC#{}", locaId);
+          }
+        }
+      }))
+    spdlog::warn("[Notify] SEH: get_PlayerUserProfile crashed");
+
+  if (!seh_call([&] {
+        auto* e       = brh->get_EnemyUserProfile();
+        auto* profile = reinterpret_cast<UserProfile*>(e);
+        if (profile) {
+          auto* nameStr = profile->Name;
+          if (nameStr) result.enemyName = to_string(nameStr);
+          if (result.enemyName.empty()) {
+            auto locaId = profile->LocaId;
+            if (locaId > 0) result.enemyName = fmt::format("NPC#{}", locaId);
+          }
+        }
+      }))
+    spdlog::warn("[Notify] SEH: get_EnemyUserProfile crashed");
+
+  if (!seh_call([&] {
+        auto hid          = brh->PlayerShipHullId;
+        result.playerShip = resolve_hull_name(brh, hid);
+      }))
+    spdlog::warn("[Notify] SEH: PlayerShipHullId crashed");
+
+  if (!seh_call([&] {
+        auto hid         = brh->EnemyShipHullId;
+        result.enemyShip = resolve_hull_name(brh, hid);
+      }))
+    spdlog::warn("[Notify] SEH: EnemyShipHullId crashed");
+
+  spdlog::info("[Notify] Battle: {} ({}) vs {} ({})", result.playerName, result.playerShip,
+               result.enemyName, result.enemyShip);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+std::string battle_notify_parse(Toast* toast)
+{
+  auto state = toast->get_State();
+
+  switch (state) {
+    case Victory:
+    case Defeat:
+    case PartialVictory:
+    case StationVictory:
+    case StationDefeat:
+    case StationBattle:
+    case IncomingAttack:
+    case FleetBattle:
+    case ArmadaBattleWon:
+    case ArmadaBattleLost:
+    case AssaultVictory:
+    case AssaultDefeat:
+      break;
+    default:
+      return {};
+  }
+
+  auto* data = toast->get_Data();
+  if (!data) return {};
+
+  auto bsd = build_battle_data(data);
+  return bsd.format_body();
+}

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -1,3 +1,12 @@
+/**
+ * @file battle_notify_parser.cc
+ * @brief Extracts battle participant names and ship hulls from combat toast data.
+ *
+ * Parses BattleResultHeader objects attached to combat-related Toast events.
+ * Uses SEH on Windows to guard against invalid IL2CPP pointers that can occur
+ * when game objects are collected mid-access. Resolves hull IDs to readable
+ * names via SpecService.
+ */
 #include "patches/battle_notify_parser.h"
 
 #include "str_utils.h"
@@ -18,9 +27,16 @@
 #include <windows.h>
 #endif
 
-// ---------------------------------------------------------------------------
-// SEH wrapper — catches access violations from bad IL2CPP pointers
-// ---------------------------------------------------------------------------
+// ─── SEH Safety Wrapper ───────────────────────────────────────────────────────────────
+
+/**
+ * @brief Execute a callable inside a Windows SEH __try/__except block.
+ *
+ * IL2CPP pointers may become invalid between frames due to GC. This wrapper
+ * catches access violations so a single bad pointer doesn't crash the mod.
+ *
+ * @return true if fn() completed without an SEH exception.
+ */
 template <typename Fn>
 static bool seh_call(Fn fn)
 {
@@ -37,10 +53,18 @@ static bool seh_call(Fn fn)
 #endif
 }
 
-// ---------------------------------------------------------------------------
-// Hull name key → human-readable name
-//   "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
-// ---------------------------------------------------------------------------
+// ─── Hull Name Parsing ───────────────────────────────────────────────────────────────
+
+/**
+ * @brief Convert an internal hull key string to a human-readable name.
+ *
+ * Strips the "Hull_" prefix and "_LIVE" suffix, replaces underscores with
+ * spaces, and converts level prefixes ("L30") to "Lv.30" format.
+ * Example: "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
+ *
+ * @param key Raw hull name key from HullSpec.
+ * @return Formatted display name.
+ */
 static std::string parse_hull_key(const std::string& key)
 {
   auto s = key;
@@ -64,9 +88,14 @@ static std::string parse_hull_key(const std::string& key)
   return s;
 }
 
-// ---------------------------------------------------------------------------
-// Resolve hull ID → display name via SpecService
-// ---------------------------------------------------------------------------
+// ─── Hull ID Resolution ──────────────────────────────────────────────────────────────
+
+/**
+ * @brief Resolve a hull ID to a display name via the game's SpecService.
+ * @param brh BattleResultHeader providing access to SpecService.
+ * @param hullId The numeric hull ID to look up.
+ * @return Parsed display name, or "Hull#<id>" if lookup fails.
+ */
 static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
 {
   if (hullId == 0) return "";
@@ -84,9 +113,9 @@ static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
   return fmt::format("Hull#{}", hullId);
 }
 
-// ---------------------------------------------------------------------------
-// Format "Name (Ship) vs Name (Ship)"
-// ---------------------------------------------------------------------------
+// ─── Battle Summary Formatting ───────────────────────────────────────────────────────
+
+/** Intermediate structure holding extracted battle participant data. */
 struct BattleSummaryData {
   std::string playerName;
   std::string enemyName;
@@ -113,9 +142,17 @@ struct BattleSummaryData {
   }
 };
 
-// ---------------------------------------------------------------------------
-// Extract player/enemy names + ship hulls from BattleResultHeader
-// ---------------------------------------------------------------------------
+// ─── BattleResultHeader Extraction ───────────────────────────────────────────────────
+
+/**
+ * @brief Extract player and enemy names + ship hull names from a BattleResultHeader.
+ *
+ * Each field extraction is wrapped in seh_call() to survive invalid pointers.
+ * Falls back to NPC LocaId formatting when player names are empty.
+ *
+ * @param data Raw Il2CppObject* from Toast::get_Data(), cast to BattleResultHeader.
+ * @return Populated BattleSummaryData (fields may be empty on failure).
+ */
 static BattleSummaryData build_battle_data(Il2CppObject* data)
 {
   BattleSummaryData result;
@@ -162,9 +199,7 @@ static BattleSummaryData build_battle_data(Il2CppObject* data)
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
+// ─── Public API ──────────────────────────────────────────────────────────────────────
 std::string battle_notify_parse(Toast* toast)
 {
   auto state = toast->get_State();

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -157,8 +157,8 @@ static BattleSummaryData build_battle_data(Il2CppObject* data)
       }))
     spdlog::warn("[Notify] SEH: EnemyShipHullId crashed");
 
-  spdlog::info("[Notify] Battle: {} ({}) vs {} ({})", result.playerName, result.playerShip,
-               result.enemyName, result.enemyShip);
+  spdlog::debug("[Notify] Battle: {} ({}) vs {} ({})", result.playerName, result.playerShip,
+                result.enemyName, result.enemyShip);
   return result;
 }
 

--- a/mods/src/patches/battle_notify_parser.h
+++ b/mods/src/patches/battle_notify_parser.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+struct Toast;
+
+// Attempt to build a detailed notification body from a battle toast's Data.
+// Returns empty string if the toast has no battle data or parsing fails.
+std::string battle_notify_parse(Toast* toast);

--- a/mods/src/patches/battle_notify_parser.h
+++ b/mods/src/patches/battle_notify_parser.h
@@ -1,9 +1,24 @@
+/**
+ * @file battle_notify_parser.h
+ * @brief Extracts player/enemy names and ship hulls from battle toast data.
+ *
+ * Parses the BattleResultHeader attached to combat-related Toast objects to
+ * produce a "Player (Ship) vs Enemy (Ship)" summary string used in OS
+ * notifications. Uses SEH guards on Windows to survive bad IL2CPP pointers.
+ */
 #pragma once
 
 #include <string>
 
 struct Toast;
 
-// Attempt to build a detailed notification body from a battle toast's Data.
-// Returns empty string if the toast has no battle data or parsing fails.
+/**
+ * @brief Build a human-readable battle summary from a toast's attached data.
+ *
+ * Only processes combat-related toast states (Victory, Defeat, etc.).
+ * Returns an empty string for non-combat toasts or when parsing fails.
+ *
+ * @param toast The game Toast object to extract battle data from.
+ * @return Formatted "Name (Ship) vs Name (Ship)" string, or empty.
+ */
 std::string battle_notify_parse(Toast* toast);

--- a/mods/src/patches/fleet_notifications.cc
+++ b/mods/src/patches/fleet_notifications.cc
@@ -178,7 +178,14 @@ void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& ship
 
   if (oldState != FleetState::Docked && newState == FleetState::Docked) {
     if (oldState == FleetState::Repairing) {
-      spdlog::debug("[FleetBar] suppress docked-after-repair id={} ship='{}'", fleetId, shipName);
+      if (!Config::Get().notifications.fleet_repair_complete) {
+        spdlog::debug("[FleetBar] suppress docked-after-repair id={} ship='{}'", fleetId, shipName);
+        return;
+      }
+
+      auto body = "Your " + shipName + " finished repairs";
+      spdlog::debug("[FleetBar] REPAIR_COMPLETE id={} ship='{}'", fleetId, shipName);
+      notification_show("Repair Complete", body.c_str());
       return;
     }
 

--- a/mods/src/patches/fleet_notifications.cc
+++ b/mods/src/patches/fleet_notifications.cc
@@ -177,6 +177,11 @@ void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& ship
   }
 
   if (oldState != FleetState::Docked && newState == FleetState::Docked) {
+    if (oldState == FleetState::Repairing) {
+      spdlog::debug("[FleetBar] suppress docked-after-repair id={} ship='{}'", fleetId, shipName);
+      return;
+    }
+
     if (!Config::Get().notifications.fleet_docked) {
       return;
     }

--- a/mods/src/patches/fleet_notifications.cc
+++ b/mods/src/patches/fleet_notifications.cc
@@ -1,0 +1,256 @@
+/**
+ * @file fleet_notifications.cc
+ * @brief Fleet notification state machine and message generation.
+ *
+ * This module tracks the last observed fleet-bar states and mining ETA hints,
+ * then emits OS notifications when meaningful fleet transitions occur.
+ */
+#include "patches/fleet_notifications.h"
+
+#include "config.h"
+#include "errormsg.h"
+#include "patches/notification_service.h"
+
+#include <prime/FleetPlayerData.h>
+#include <prime/SpecManager.h>
+#include <testable_functions.h>
+
+#include <spdlog/spdlog.h>
+#include <str_utils.h>
+
+#include <cmath>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace {
+std::unordered_map<uint64_t, FleetState>   s_fleet_bar_states;
+std::unordered_map<uint64_t, std::string>  s_fleet_bar_ship_names;
+std::unordered_map<uint64_t, std::string>  s_fleet_bar_resource_names;
+std::unordered_map<uint64_t, float>        s_fleet_bar_cargo_fill_levels;
+std::unordered_map<uint64_t, int64_t>      s_mining_viewer_remaining_seconds;
+
+std::string fleet_bar_ship_name(FleetPlayerData* fleet)
+{
+  auto* hull = fleet ? fleet->Hull : nullptr;
+  auto  name = (hull && hull->Name) ? to_string(hull->Name) : std::string{"?"};
+
+  constexpr std::string_view live_suffix = "_LIVE";
+  if (name.size() >= live_suffix.size() &&
+      name.compare(name.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
+    name.erase(name.size() - live_suffix.size());
+  }
+
+  for (auto& ch : name) {
+    if (ch == '_') {
+      ch = ' ';
+    }
+  }
+
+  return name;
+}
+
+std::string fleet_bar_cached_ship_name(uint64_t fleetId)
+{
+  auto it = s_fleet_bar_ship_names.find(fleetId);
+  if (it == s_fleet_bar_ship_names.end()) {
+    return {};
+  }
+
+  return it->second;
+}
+
+std::string fleet_bar_cached_resource_name(uint64_t fleetId)
+{
+  auto it = s_fleet_bar_resource_names.find(fleetId);
+  if (it == s_fleet_bar_resource_names.end()) {
+    return {};
+  }
+
+  return it->second;
+}
+
+float fleet_bar_cached_cargo_fill_level(uint64_t fleetId)
+{
+  auto it = s_fleet_bar_cargo_fill_levels.find(fleetId);
+  if (it == s_fleet_bar_cargo_fill_levels.end()) {
+    return -1.0f;
+  }
+
+  return it->second;
+}
+
+std::string normalize_resource_name(const std::string& name)
+{
+  if (name.empty()) {
+    return {};
+  }
+
+  auto normalized = name;
+  constexpr std::string_view live_suffix = "_LIVE";
+  if (normalized.size() >= live_suffix.size()
+      && normalized.compare(normalized.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
+    normalized.erase(normalized.size() - live_suffix.size());
+  }
+
+  for (auto& ch : normalized) {
+    if (ch == '_') {
+      ch = ' ';
+    }
+  }
+
+  constexpr std::string_view resource_prefix = "Resource ";
+  if (normalized.size() >= resource_prefix.size()
+      && normalized.compare(0, resource_prefix.size(), resource_prefix) == 0) {
+    normalized.erase(0, resource_prefix.size());
+  }
+
+  return normalized;
+}
+
+std::string fleet_bar_resource_name(FleetPlayerData* fleet)
+{
+  auto* miningData = fleet ? fleet->MiningData : nullptr;
+  if (!miningData) {
+    return {};
+  }
+
+  const auto resourceId = miningData->ResourceId;
+  auto* specManager = SpecManager::Instance();
+  if (!specManager) {
+    return {};
+  }
+
+  auto* resourceSpec = specManager->GetResourceSpec(resourceId);
+  auto* rawName      = resourceSpec ? resourceSpec->Name : nullptr;
+  auto  rawNameText  = rawName ? to_string(rawName) : std::string{};
+  return normalize_resource_name(rawNameText);
+}
+
+std::string fleet_cargo_fill_text(float fillLevel)
+{
+  return format_cargo_fill_text(fillLevel);
+}
+
+int64_t duration_ticks_to_seconds(int64_t ticks)
+{
+  if (ticks < 0) {
+    return -1;
+  }
+
+  return static_cast<int64_t>(std::llround(static_cast<double>(ticks) / 10000000.0));
+}
+
+void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName,
+                                       FleetState oldState, FleetState newState,
+                                       const std::string& resourceName,
+                                       const std::string& cargoText)
+{
+  if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
+    if (!Config::Get().notifications.fleet_arrived_in_system) {
+      return;
+    }
+
+    auto body = "Your " + shipName + " has arrived in-system";
+    spdlog::debug("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
+    notification_show("Fleet Arrived", body.c_str());
+    return;
+  }
+
+  if (oldState != FleetState::Mining && newState == FleetState::Mining) {
+    if (!Config::Get().notifications.fleet_started_mining) {
+      return;
+    }
+
+    auto it      = s_mining_viewer_remaining_seconds.find(fleetId);
+    auto etaText = (it != s_mining_viewer_remaining_seconds.end()) ? format_duration_short(it->second)
+                                                                   : std::string{};
+    auto title   = format_started_mining_title(shipName, resourceName);
+    auto body    = format_started_mining_body(etaText, cargoText);
+    s_mining_viewer_remaining_seconds.erase(fleetId);
+    notification_show(title.c_str(), body.c_str());
+    return;
+  }
+
+  if (oldState == FleetState::Mining && newState != FleetState::Mining) {
+    s_mining_viewer_remaining_seconds.erase(fleetId);
+  }
+
+  if (oldState != FleetState::Docked && newState == FleetState::Docked) {
+    if (!Config::Get().notifications.fleet_docked) {
+      return;
+    }
+
+    auto body = "Your " + shipName + " docked";
+    spdlog::debug("[FleetBar] DOCKED id={} ship='{}'", fleetId, shipName);
+    notification_show("Fleet Docked", body.c_str());
+    return;
+  }
+}
+} // namespace
+
+void fleet_notifications_init()
+{
+  notification_init();
+}
+
+void fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet)
+{
+  if (!fleet) {
+    return;
+  }
+
+  auto fleetId         = fleet->Id;
+  auto currentState    = fleet->CurrentState;
+  auto shipName        = fleet_bar_ship_name(fleet);
+  auto resourceName    = fleet_bar_resource_name(fleet);
+  auto cargoFillLevel  = fleet->CargoResourceFillLevel;
+  auto cargoText       = fleet_cargo_fill_text(cargoFillLevel);
+
+  auto it               = s_fleet_bar_states.find(fleetId);
+  auto previousState    = FleetState::Unknown;
+  auto hadPreviousState = false;
+  if (it != s_fleet_bar_states.end()) {
+    previousState    = it->second;
+    hadPreviousState = true;
+  }
+
+  s_fleet_bar_states[fleetId] = currentState;
+  s_fleet_bar_ship_names[fleetId] = shipName;
+  if (!resourceName.empty()) {
+    s_fleet_bar_resource_names[fleetId] = resourceName;
+  }
+  s_fleet_bar_cargo_fill_levels[fleetId] = cargoFillLevel;
+
+  if (hadPreviousState && previousState != currentState) {
+    maybe_notify_fleet_bar_transition(fleetId, shipName, previousState, currentState, resourceName, cargoText);
+  }
+}
+
+void fleet_notifications_observe_node_depleted(int64_t fleetId)
+{
+  if (!Config::Get().notifications.fleet_node_depleted) {
+    return;
+  }
+
+  auto shipName     = fleet_bar_cached_ship_name(static_cast<uint64_t>(fleetId));
+  auto resourceName = fleet_bar_cached_resource_name(static_cast<uint64_t>(fleetId));
+  auto cargoText    = fleet_cargo_fill_text(fleet_bar_cached_cargo_fill_level(static_cast<uint64_t>(fleetId)));
+
+  s_mining_viewer_remaining_seconds.erase(static_cast<uint64_t>(fleetId));
+
+  auto body = format_node_depleted_body(shipName, resourceName, cargoText);
+  notification_show("Node Depleted", body.c_str());
+}
+
+void fleet_notifications_observe_mining_timer(FleetPlayerData* selectedFleet, int64_t remainingTicks)
+{
+  if (!selectedFleet) {
+    return;
+  }
+
+  auto remainingSeconds = duration_ticks_to_seconds(remainingTicks);
+  if (remainingSeconds > 0) {
+    s_mining_viewer_remaining_seconds[selectedFleet->Id] = remainingSeconds;
+  }
+}

--- a/mods/src/patches/fleet_notifications.h
+++ b/mods/src/patches/fleet_notifications.h
@@ -1,0 +1,38 @@
+/**
+ * @file fleet_notifications.h
+ * @brief Fleet notification runtime logic independent from hook installation.
+ *
+ * The hook layer captures live fleet-bar and mining-viewer events, then hands
+ * those observations to this module. This file contains the notification state
+ * machine and message formatting, while the `parts/` layer stays limited to
+ * IL2CPP method discovery and hook injection.
+ */
+#pragma once
+
+#include <cstdint>
+
+struct FleetPlayerData;
+
+/**
+ * @brief Initialize notification dependencies used by fleet notifications.
+ */
+void fleet_notifications_init();
+
+/**
+ * @brief Observe a fleet-bar state refresh and emit notifications as needed.
+ * @param fleet The fleet currently bound to the widget.
+ */
+void fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet);
+
+/**
+ * @brief Observe a mining node depletion event for a fleet.
+ * @param fleetId Stable fleet id provided by the game's observer callback.
+ */
+void fleet_notifications_observe_node_depleted(int64_t fleetId);
+
+/**
+ * @brief Observe the current mining ETA from the mining viewer.
+ * @param selectedFleet The fleet currently bound to the mining viewer.
+ * @param remainingTicks Remaining time in .NET TimeSpan ticks.
+ */
+void fleet_notifications_observe_mining_timer(FleetPlayerData* selectedFleet, int64_t remainingTicks);

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,3 +1,11 @@
+/**
+ * @file notification_service.cc
+ * @brief OS-native notification delivery for in-game toast events.
+ *
+ * Resolves IL2CPP LanguageManager::Localize at init time, maps toast states
+ * to human-readable titles, strips Unity rich text tags from body text, and
+ * delivers Windows toast notifications via WinRT for configured toast types.
+ */
 #include "patches/notification_service.h"
 #include "patches/battle_notify_parser.h"
 
@@ -10,7 +18,14 @@
 
 #include <spdlog/spdlog.h>
 
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
 #include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
 
 #if _WIN32
 #include <windows.h>
@@ -18,15 +33,19 @@
 #include <winrt/Windows.UI.Notifications.h>
 #endif
 
-// ---------------------------------------------------------------------------
-// IL2CPP method cache
-// ---------------------------------------------------------------------------
+// ─── IL2CPP Method Cache ──────────────────────────────────────────────────────────────
+
+/** Cached LanguageManager::Localize(out string, LocaleTextContext) method pointer. */
 static const MethodInfo* s_localize_ltc = nullptr;
 static bool              s_notification_initialized = false;
 
-// ---------------------------------------------------------------------------
-// Toast state → human-readable title
-// ---------------------------------------------------------------------------
+// ─── Toast State → Human-Readable Title ───────────────────────────────────────────────
+
+/**
+ * @brief Map a numeric toast state to a notification title string.
+ * @param state The Toast::State enum value.
+ * @return Static title string, or nullptr for unmapped states.
+ */
 static const char* toast_state_title(int state)
 {
   switch (state) {
@@ -73,20 +92,215 @@ static const char* toast_state_title(int state)
   }
 }
 
-// ---------------------------------------------------------------------------
-// Platform notification delivery
-// ---------------------------------------------------------------------------
+// ─── Platform Notification Delivery ──────────────────────────────────────────────────
 #if _WIN32
+struct NotificationRequest {
+  std::string source;
+  std::string title;
+  std::string body;
+  std::chrono::steady_clock::time_point queued_at;
+};
+
+static std::mutex              s_notification_queue_mutex;
+static std::condition_variable s_notification_queue_condition;
+static std::deque<NotificationRequest> s_notification_queue;
+static std::once_flag          s_notification_worker_once;
+static constexpr auto          kNotificationCoalesceWindow   = std::chrono::milliseconds(750);
+static constexpr size_t        kNotificationSummaryLimit     = 4;
+
+static std::string normalize_notification_body(const char* body)
+{
+  if (!body || !*body) {
+    return {};
+  }
+
+  std::string normalized;
+  normalized.reserve(std::string_view(body).size());
+
+  for (size_t i = 0; body[i] != '\0'; ++i) {
+    if (body[i] == '\r') {
+      normalized += '\r';
+      if (body[i + 1] == '\n') {
+        normalized += '\n';
+        ++i;
+      }
+      continue;
+    }
+
+    if (body[i] == '\n') {
+      normalized += "\r\n";
+      continue;
+    }
+
+    normalized += body[i];
+  }
+
+  return normalized;
+}
+
+static std::string flatten_notification_text(std::string_view text)
+{
+  std::string flattened;
+  flattened.reserve(text.size());
+
+  bool last_was_space = false;
+  for (char ch : text) {
+    if (ch == '\r' || ch == '\n' || ch == '\t') {
+      ch = ' ';
+    }
+
+    if (ch == ' ') {
+      if (flattened.empty() || last_was_space) {
+        continue;
+      }
+
+      last_was_space = true;
+      flattened += ch;
+      continue;
+    }
+
+    last_was_space = false;
+    flattened += ch;
+  }
+
+  if (!flattened.empty() && flattened.back() == ' ') {
+    flattened.pop_back();
+  }
+
+  return flattened;
+}
+
+static std::string escape_notification_text_for_log(std::string_view text)
+{
+  std::string escaped;
+  escaped.reserve(text.size());
+
+  for (char ch : text) {
+    switch (ch) {
+      case '\r':
+        escaped += "\\r";
+        break;
+      case '\n':
+        escaped += "\\n";
+        break;
+      case '\t':
+        escaped += "\\t";
+        break;
+      default:
+        escaped += ch;
+        break;
+    }
+  }
+
+  return escaped;
+}
+
+static NotificationRequest collapse_notification_batch(std::vector<NotificationRequest>&& batch)
+{
+  if (batch.empty()) {
+    return {};
+  }
+
+  if (batch.size() == 1) {
+    return std::move(batch.front());
+  }
+
+  bool same_title = true;
+  for (size_t i = 1; i < batch.size(); ++i) {
+    if (batch[i].title != batch.front().title) {
+      same_title = false;
+      break;
+    }
+  }
+
+  NotificationRequest collapsed;
+  if (same_title) {
+    collapsed.title = batch.front().title + " (" + std::to_string(batch.size()) + ")";
+  } else {
+    collapsed.title = std::to_string(batch.size()) + " Notifications";
+  }
+
+  size_t appended = 0;
+  for (size_t i = 0; i < batch.size() && appended < kNotificationSummaryLimit; ++i) {
+    auto title = flatten_notification_text(batch[i].title);
+    auto body  = flatten_notification_text(batch[i].body);
+
+    std::string line;
+    if (same_title) {
+      line = body.empty() ? title : body;
+    } else if (body.empty()) {
+      line = title;
+    } else {
+      line = title + ": " + body;
+    }
+
+    if (line.empty()) {
+      continue;
+    }
+
+    if (!collapsed.body.empty()) {
+      collapsed.body += "\n";
+    }
+    collapsed.body += line;
+    ++appended;
+  }
+
+  if (batch.size() > appended) {
+    if (!collapsed.body.empty()) {
+      collapsed.body += "\n";
+    }
+    collapsed.body += "+" + std::to_string(batch.size() - appended) + " more";
+  }
+
+  return collapsed;
+}
+
+static std::string notification_batch_preview(const std::vector<NotificationRequest>& batch)
+{
+  std::string preview;
+  size_t appended = 0;
+
+  for (const auto& item : batch) {
+    if (appended >= kNotificationSummaryLimit) {
+      break;
+    }
+
+    auto title = flatten_notification_text(item.title);
+    if (title.empty()) {
+      title = "(untitled)";
+    }
+
+    if (!preview.empty()) {
+      preview += ", ";
+    }
+    preview += item.source + ":" + title;
+    ++appended;
+  }
+
+  if (batch.size() > appended) {
+    preview += ", +" + std::to_string(batch.size() - appended) + " more";
+  }
+
+  return preview;
+}
+
 static void show_system_notification(const char* title, const char* body)
 {
   try {
     using namespace winrt::Windows::UI::Notifications;
     using namespace winrt::Windows::Data::Xml::Dom;
 
-    auto xml   = ToastNotificationManager::GetTemplateContent(ToastTemplateType::ToastText02);
+    auto normalizedBody = normalize_notification_body(body);
+    spdlog::debug("[NotifyQueue] show title='{}' body='{}'",
+                  title ? escape_notification_text_for_log(title) : "",
+                  escape_notification_text_for_log(normalizedBody));
+    auto xml = ToastNotificationManager::GetTemplateContent(normalizedBody.empty() ? ToastTemplateType::ToastText01
+                                                                                   : ToastTemplateType::ToastText02);
     auto nodes = xml.GetElementsByTagName(L"text");
     nodes.Item(0).InnerText(winrt::to_hstring(title));
-    nodes.Item(1).InnerText(winrt::to_hstring(body));
+    if (!normalizedBody.empty()) {
+      nodes.Item(1).InnerText(winrt::to_hstring(normalizedBody));
+    }
 
     auto notification = ToastNotification(xml);
     auto notifier     = ToastNotificationManager::CreateToastNotifier(L"Star Trek Fleet Command");
@@ -97,11 +311,95 @@ static void show_system_notification(const char* title, const char* body)
     spdlog::warn("[Notify] WinRT notification failed (unknown error)");
   }
 }
+
+static void queue_system_notification(const char* title, const char* body, const char* source)
+{
+  NotificationRequest request;
+  if (source) {
+    request.source = source;
+  }
+  if (title) {
+    request.title = title;
+  }
+  if (body) {
+    request.body = body;
+  }
+  request.queued_at = std::chrono::steady_clock::now();
+
+  size_t queue_size = 0;
+  {
+    std::lock_guard lock(s_notification_queue_mutex);
+    s_notification_queue.emplace_back(std::move(request));
+    queue_size = s_notification_queue.size();
+  }
+
+  spdlog::debug("[NotifyQueue] enqueue source={} title='{}' queue_size={}",
+                source ? source : "unknown",
+                title ? flatten_notification_text(title) : "",
+                queue_size);
+
+  s_notification_queue_condition.notify_one();
+}
+
+static void notification_worker_main()
+{
+  try { winrt::init_apartment(); } catch (...) {}
+
+  for (;;) {
+    std::vector<NotificationRequest> batch;
+
+    {
+      std::unique_lock lock(s_notification_queue_mutex);
+      s_notification_queue_condition.wait(lock, []() { return !s_notification_queue.empty(); });
+
+      auto observed_size = s_notification_queue.size();
+      while (s_notification_queue_condition.wait_for(lock, kNotificationCoalesceWindow, [&] {
+        return s_notification_queue.size() != observed_size;
+      })) {
+        observed_size = s_notification_queue.size();
+      }
+
+      while (!s_notification_queue.empty()) {
+        batch.emplace_back(std::move(s_notification_queue.front()));
+        s_notification_queue.pop_front();
+      }
+    }
+
+    if (batch.empty()) {
+      continue;
+    }
+
+    const auto batch_start = batch.front().queued_at;
+    const auto batch_end   = batch.back().queued_at;
+    const auto batch_span  = std::chrono::duration_cast<std::chrono::milliseconds>(batch_end - batch_start).count();
+    const auto batch_preview = notification_batch_preview(batch);
+    const auto batch_count = batch.size();
+
+    auto collapsed = collapse_notification_batch(std::move(batch));
+    if (!collapsed.title.empty()) {
+      spdlog::debug("[NotifyQueue] flush count={} span_ms={} preview=[{}] collapsed_title='{}' collapsed_body='{}'",
+                    batch_count,
+                    batch_span,
+                    batch_preview,
+                    escape_notification_text_for_log(collapsed.title),
+                    escape_notification_text_for_log(collapsed.body));
+      show_system_notification(collapsed.title.c_str(), collapsed.body.c_str());
+    }
+  }
+}
 #endif
 
-// ---------------------------------------------------------------------------
-// Resolve basic localized text from a Toast's TextLocaleTextContext
-// ---------------------------------------------------------------------------
+// ─── Toast Text Resolution ───────────────────────────────────────────────────────────
+
+/**
+ * @brief Resolve the localized body text from a Toast's TextLocaleTextContext.
+ *
+ * Invokes the cached LanguageManager::Localize method via il2cpp_runtime_invoke
+ * to produce a localized string from the toast's LTC data.
+ *
+ * @param toast The Toast to extract text from.
+ * @return Localized text string, or empty on failure.
+ */
 static std::string resolve_toast_text(Toast* toast)
 {
   if (!s_localize_ltc) return {};
@@ -121,9 +419,11 @@ static std::string resolve_toast_text(Toast* toast)
   return to_string(resolved);
 }
 
-// ---------------------------------------------------------------------------
-// Strip Unity rich text tags (e.g. <color=#FF0000>, <b>, </size>)
-// ---------------------------------------------------------------------------
+/**
+ * @brief Strip Unity rich text tags (e.g. \<color=#FF0000\>, \<b\>, \</size\>).
+ * @param s Input string potentially containing Unity markup.
+ * @return Clean string with all angle-bracket tags removed.
+ */
 static std::string strip_unity_rich_text(const std::string& s)
 {
   std::string result;
@@ -139,9 +439,7 @@ static std::string strip_unity_rich_text(const std::string& s)
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
+// ─── Public API ──────────────────────────────────────────────────────────────────────
 
 void notification_init()
 {
@@ -174,6 +472,9 @@ void notification_init()
 
 #if _WIN32
   try { winrt::init_apartment(); } catch (...) {}
+  std::call_once(s_notification_worker_once, []() {
+    std::thread(notification_worker_main).detach();
+  });
   spdlog::debug("[Notify] Windows notification service initialized");
 #else
   spdlog::debug("[Notify] Notification service: platform not supported (no-op)");
@@ -185,7 +486,11 @@ void notification_init()
 void notification_show(const char* title, const char* body)
 {
 #if _WIN32
-  show_system_notification(title, body);
+  if (!Config::Get().notifications.enabled) {
+    return;
+  }
+
+  queue_system_notification(title, body, "direct");
 #endif
 }
 
@@ -194,11 +499,14 @@ void notification_handle_toast(Toast* toast)
 #if !_WIN32
   return; // No notification delivery on non-Windows platforms yet
 #else
+  const auto& notifications = Config::Get().notifications;
+  if (!notifications.enabled) {
+    return;
+  }
+
   auto state = toast->get_State();
 
-  // Check if this toast type is in the user's notify list
-  const auto& notify_types = Config::Get().notify_banner_types;
-  if (std::ranges::find(notify_types, state) == notify_types.end()) {
+  if (!notifications.EnabledForToastState(state)) {
     return;
   }
 
@@ -217,6 +525,6 @@ void notification_handle_toast(Toast* toast)
   }
 
   spdlog::debug("[Notify] {} — {}", title, body);
-  show_system_notification(title, body.c_str());
+  queue_system_notification(title, body.c_str(), "toast");
 #endif
 }

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,0 +1,205 @@
+#include "patches/notification_service.h"
+
+#include "config.h"
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/LanguageManager.h>
+#include <prime/Toast.h>
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#include <winrt/Windows.Data.Xml.Dom.h>
+#include <winrt/Windows.UI.Notifications.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// IL2CPP method cache
+// ---------------------------------------------------------------------------
+static const MethodInfo* s_localize_ltc = nullptr;
+
+// ---------------------------------------------------------------------------
+// Toast state → human-readable title
+// ---------------------------------------------------------------------------
+static const char* toast_state_title(int state)
+{
+  switch (state) {
+    case Victory:                   return "Victory!";
+    case Defeat:                    return "Defeat";
+    case PartialVictory:            return "Partial Victory";
+    case StationVictory:            return "Station Victory!";
+    case StationDefeat:             return "Station Defeat";
+    case StationBattle:             return "Station Under Attack!";
+    case IncomingAttack:            return "Incoming Attack!";
+    case IncomingAttackFaction:     return "Incoming Faction Attack!";
+    case FleetBattle:               return "Fleet Battle";
+    case ArmadaBattleWon:           return "Armada Victory!";
+    case ArmadaBattleLost:          return "Armada Defeated";
+    case ArmadaCreated:             return "Armada Created";
+    case ArmadaCanceled:            return "Armada Canceled";
+    case ArmadaIncomingAttack:      return "Armada Under Attack!";
+    case AssaultVictory:            return "Assault Victory!";
+    case AssaultDefeat:             return "Assault Defeat";
+    case Tournament:                return "Event Progress";
+    case ChainedEventScored:        return "Event Progress";
+    case Achievement:               return "Achievement";
+    case ChallengeComplete:         return "Challenge Complete";
+    case ChallengeFailed:           return "Challenge Failed";
+    case TakeoverVictory:           return "Takeover Victory!";
+    case TakeoverDefeat:            return "Takeover Defeat";
+    case TreasuryProgress:          return "Treasury Progress";
+    case TreasuryFull:              return "Treasury Full";
+    case WarchestProgress:          return "Warchest Progress";
+    case WarchestFull:              return "Warchest Full";
+    case FactionLevelUp:            return "Faction Level Up";
+    case FactionLevelDown:          return "Faction Level Down";
+    case FactionDiscovered:         return "Faction Discovered";
+    case FactionWarning:            return "Faction Warning";
+    case DiplomacyUpdated:          return "Diplomacy Updated";
+    case StrikeHit:                 return "Strike Hit";
+    case StrikeDefeat:              return "Strike Defeat";
+    case SurgeWarmUpEnded:          return "Surge Started";
+    case SurgeHostileGroupDefeated: return "Surge Hostiles Defeated";
+    case SurgeTimeLeft:             return "Surge Time Warning";
+    case ArenaTimeLeft:             return "Arena Time Warning";
+    case FleetPresetApplied:        return "Fleet Preset Applied";
+    default:                        return nullptr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform notification delivery
+// ---------------------------------------------------------------------------
+#if _WIN32
+static void show_system_notification(const char* title, const char* body)
+{
+  try {
+    using namespace winrt::Windows::UI::Notifications;
+    using namespace winrt::Windows::Data::Xml::Dom;
+
+    auto xml   = ToastNotificationManager::GetTemplateContent(ToastTemplateType::ToastText02);
+    auto nodes = xml.GetElementsByTagName(L"text");
+    nodes.Item(0).InnerText(winrt::to_hstring(title));
+    nodes.Item(1).InnerText(winrt::to_hstring(body));
+
+    auto notification = ToastNotification(xml);
+    auto notifier     = ToastNotificationManager::CreateToastNotifier(L"Star Trek Fleet Command");
+    notifier.Show(notification);
+  } catch (const winrt::hresult_error& e) {
+    spdlog::warn("[Notify] WinRT notification failed: {}", winrt::to_string(e.message()));
+  } catch (...) {
+    spdlog::warn("[Notify] WinRT notification failed (unknown error)");
+  }
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// Resolve basic localized text from a Toast's TextLocaleTextContext
+// ---------------------------------------------------------------------------
+static std::string resolve_toast_text(Toast* toast)
+{
+  if (!s_localize_ltc) return {};
+
+  auto* ltc = toast->get_TextLocaleTextContext();
+  if (!ltc) return {};
+
+  auto* langMgr = LanguageManager::Instance();
+  if (!langMgr) return {};
+
+  Il2CppString*  resolved = nullptr;
+  void*          params[2] = { &resolved, ltc };
+  Il2CppException* exc = nullptr;
+  il2cpp_runtime_invoke(s_localize_ltc, langMgr, params, &exc);
+
+  if (exc || !resolved) return {};
+  return to_string(resolved);
+}
+
+// ---------------------------------------------------------------------------
+// Strip Unity rich text tags (e.g. <color=#FF0000>, <b>, </size>)
+// ---------------------------------------------------------------------------
+static std::string strip_unity_rich_text(const std::string& s)
+{
+  std::string result;
+  result.reserve(s.size());
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '<') {
+      auto end = s.find('>', i);
+      if (end != std::string::npos) { i = end + 1; continue; }
+    }
+    result += s[i++];
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void notification_init()
+{
+  // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
+  // 2-parameter overload that takes an LTC and returns a localized string.
+  auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
+  if (lm_helper.isValidHelper()) {
+    auto* cls = lm_helper.get_cls();
+    if (cls) {
+      void* iter = nullptr;
+      while (auto* method = il2cpp_class_get_methods(cls, &iter)) {
+        auto name = std::string_view(il2cpp_method_get_name(method));
+        auto pc   = il2cpp_method_get_param_count(method);
+        if (name == "Localize" && pc == 2) {
+          s_localize_ltc = method;
+          spdlog::info("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
+          break;
+        }
+      }
+    }
+  }
+
+  if (!s_localize_ltc) {
+    spdlog::warn("[Notify] Could not resolve LanguageManager::Localize — notifications will show titles only");
+  }
+
+#if _WIN32
+  try { winrt::init_apartment(); } catch (...) {}
+  spdlog::info("[Notify] Windows notification service initialized");
+#else
+  spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+}
+
+void notification_handle_toast(Toast* toast)
+{
+#if !_WIN32
+  return; // No notification delivery on non-Windows platforms yet
+#else
+  auto state = toast->get_State();
+
+  // Check if this toast type is in the user's notify list
+  const auto& notify_types = Config::Get().notify_banner_types;
+  if (std::ranges::find(notify_types, state) == notify_types.end()) {
+    return;
+  }
+
+  auto* title = toast_state_title(state);
+  if (!title) {
+    spdlog::debug("[Notify] No title mapping for toast state {}, skipping", state);
+    return;
+  }
+
+  auto body = strip_unity_rich_text(resolve_toast_text(toast));
+  if (body.empty()) {
+    body = "(no details available)";
+  }
+
+  spdlog::info("[Notify] {} — {}", title, body);
+  show_system_notification(title, body.c_str());
+#endif
+}

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -161,7 +161,7 @@ void notification_init()
         auto pc   = il2cpp_method_get_param_count(method);
         if (name == "Localize" && pc == 2) {
           s_localize_ltc = method;
-          spdlog::info("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
+          spdlog::debug("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
           break;
         }
       }
@@ -174,9 +174,9 @@ void notification_init()
 
 #if _WIN32
   try { winrt::init_apartment(); } catch (...) {}
-  spdlog::info("[Notify] Windows notification service initialized");
+  spdlog::debug("[Notify] Windows notification service initialized");
 #else
-  spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+  spdlog::debug("[Notify] Notification service: platform not supported (no-op)");
 #endif
 
   s_notification_initialized = true;
@@ -216,7 +216,7 @@ void notification_handle_toast(Toast* toast)
     body = "(no details available)";
   }
 
-  spdlog::info("[Notify] {} — {}", title, body);
+  spdlog::debug("[Notify] {} — {}", title, body);
   show_system_notification(title, body.c_str());
 #endif
 }

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -10,7 +10,6 @@
 
 #include <spdlog/spdlog.h>
 
-#include <algorithm>
 #include <string>
 
 #if _WIN32

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -16,6 +16,7 @@
 #include <prime/LanguageManager.h>
 #include <prime/Toast.h>
 
+#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
 #include <chrono>
@@ -391,6 +392,8 @@ static void notification_worker_main()
 
 // ─── Toast Text Resolution ───────────────────────────────────────────────────────────
 
+static std::string strip_unity_rich_text(const std::string& s);
+
 /**
  * @brief Resolve the localized body text from a Toast's TextLocaleTextContext.
  *
@@ -417,6 +420,129 @@ static std::string resolve_toast_text(Toast* toast)
 
   if (exc || !resolved) return {};
   return to_string(resolved);
+}
+
+static std::string resolve_ltc_param(Il2CppObject* obj)
+{
+  if (!obj) {
+    return {};
+  }
+
+  auto* klass = obj->klass;
+  if (!klass) {
+    return "?";
+  }
+
+  auto name = std::string_view(il2cpp_class_get_name(klass));
+
+  if (name == "LocaleTextContext") {
+    if (s_localize_ltc) {
+      auto* langMgr = LanguageManager::Instance();
+      if (langMgr) {
+        Il2CppString*  resolved = nullptr;
+        void*          params[2] = { &resolved, obj };
+        Il2CppException* exc = nullptr;
+        il2cpp_runtime_invoke(s_localize_ltc, langMgr, params, &exc);
+        if (!exc && resolved) {
+          return to_string(resolved);
+        }
+      }
+    }
+
+    auto* identifier = *reinterpret_cast<Il2CppString**>(reinterpret_cast<char*>(obj) + 16);
+    return identifier ? to_string(identifier) : "?";
+  }
+
+  if (name == "String") {
+    return to_string(reinterpret_cast<Il2CppString*>(obj));
+  }
+
+  if (name == "BoxedDouble" || name == "BoxedFloat" || name == "BoxedInt" || name == "BoxedLong") {
+    void* iter = nullptr;
+    while (auto* field = il2cpp_class_get_fields(klass, &iter)) {
+      auto field_offset = il2cpp_field_get_offset(field);
+      auto* field_type  = il2cpp_field_get_type(field);
+      auto field_type_id = il2cpp_type_get_type(field_type);
+
+      if (field_type_id == 13) {
+        auto value = *reinterpret_cast<double*>(reinterpret_cast<char*>(obj) + field_offset);
+        if (value == static_cast<int64_t>(value)) {
+          return fmt::format("{}", static_cast<int64_t>(value));
+        }
+        return fmt::format("{:.1f}", value);
+      }
+
+      if (field_type_id == 12) {
+        auto value = *reinterpret_cast<float*>(reinterpret_cast<char*>(obj) + field_offset);
+        return fmt::format("{:.1f}", value);
+      }
+
+      if (field_type_id == 8) {
+        auto value = *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(obj) + field_offset);
+        return fmt::format("{}", value);
+      }
+
+      if (field_type_id == 10) {
+        auto value = *reinterpret_cast<int64_t*>(reinterpret_cast<char*>(obj) + field_offset);
+        return fmt::format("{}", value);
+      }
+    }
+  }
+
+  if (name == "Double") {
+    auto value = *reinterpret_cast<double*>(reinterpret_cast<char*>(obj) + 0x10);
+    if (value == static_cast<int64_t>(value)) {
+      return fmt::format("{}", static_cast<int64_t>(value));
+    }
+    return fmt::format("{:.1f}", value);
+  }
+
+  if (name == "Int32") {
+    auto value = *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(obj) + 0x10);
+    return fmt::format("{}", value);
+  }
+
+  if (name == "Int64") {
+    auto value = *reinterpret_cast<int64_t*>(reinterpret_cast<char*>(obj) + 0x10);
+    return fmt::format("{}", value);
+  }
+
+  if (name == "Single") {
+    auto value = *reinterpret_cast<float*>(reinterpret_cast<char*>(obj) + 0x10);
+    return fmt::format("{:.1f}", value);
+  }
+
+  return fmt::format("<{}>", name);
+}
+
+static std::string resolve_ltc_formatted(void* ltc, std::string_view template_text)
+{
+  if (!ltc) {
+    return strip_unity_rich_text(std::string(template_text));
+  }
+
+  auto* ltc_object = reinterpret_cast<Il2CppObject*>(ltc);
+  auto* text_parameters = *reinterpret_cast<Il2CppArray**>(reinterpret_cast<char*>(ltc_object) + 64);
+  if (!text_parameters) {
+    return strip_unity_rich_text(std::string(template_text));
+  }
+
+  auto length = il2cpp_array_length(text_parameters);
+  auto* elements = reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(text_parameters) + sizeof(Il2CppArray));
+
+  auto result = std::string(template_text);
+  for (il2cpp_array_size_t i = 0; i < length && i < 16; ++i) {
+    auto placeholder = fmt::format("{{{}}}", i);
+    auto replacement = resolve_ltc_param(elements[i]);
+
+    size_t position = 0;
+    while ((position = result.find(placeholder, position)) != std::string::npos) {
+      result.replace(position, placeholder.size(), replacement);
+      position += replacement.size();
+    }
+  }
+
+  return strip_unity_rich_text(result);
 }
 
 /**
@@ -516,9 +642,17 @@ void notification_handle_toast(Toast* toast)
     return;
   }
 
-  auto body = battle_notify_parse(toast);
+  auto* ltc = toast->get_TextLocaleTextContext();
+
+  auto parsed_body = battle_notify_parse(toast);
+  std::string localized_body;
+  auto body = parsed_body;
   if (body.empty()) {
-    body = strip_unity_rich_text(resolve_toast_text(toast));
+    localized_body = resolve_toast_text(toast);
+    body = resolve_ltc_formatted(ltc, localized_body);
+  }
+  if (body.empty()) {
+    body = strip_unity_rich_text(localized_body);
   }
   if (body.empty()) {
     body = "(no details available)";

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,4 +1,5 @@
 #include "patches/notification_service.h"
+#include "patches/battle_notify_parser.h"
 
 #include "config.h"
 #include "str_utils.h"
@@ -194,7 +195,10 @@ void notification_handle_toast(Toast* toast)
     return;
   }
 
-  auto body = strip_unity_rich_text(resolve_toast_text(toast));
+  auto body = battle_notify_parse(toast);
+  if (body.empty()) {
+    body = strip_unity_rich_text(resolve_toast_text(toast));
+  }
   if (body.empty()) {
     body = "(no details available)";
   }

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -22,6 +22,7 @@
 // IL2CPP method cache
 // ---------------------------------------------------------------------------
 static const MethodInfo* s_localize_ltc = nullptr;
+static bool              s_notification_initialized = false;
 
 // ---------------------------------------------------------------------------
 // Toast state → human-readable title
@@ -144,6 +145,10 @@ static std::string strip_unity_rich_text(const std::string& s)
 
 void notification_init()
 {
+  if (s_notification_initialized) {
+    return;
+  }
+
   // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
   // 2-parameter overload that takes an LTC and returns a localized string.
   auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
@@ -172,6 +177,15 @@ void notification_init()
   spdlog::info("[Notify] Windows notification service initialized");
 #else
   spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+
+  s_notification_initialized = true;
+}
+
+void notification_show(const char* title, const char* body)
+{
+#if _WIN32
+  show_system_notification(title, body);
 #endif
 }
 

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -1,0 +1,10 @@
+#pragma once
+
+struct Toast;
+
+// Initialize the notification service (resolve IL2CPP methods, init platform).
+// Call once during InstallToastBannerHooks().
+void notification_init();
+
+// Called from toast hooks — checks config, formats, and delivers notification.
+void notification_handle_toast(Toast* toast);

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -8,3 +8,13 @@ void notification_init();
 
 // Called from toast hooks — checks config, formats, and delivers notification.
 void notification_handle_toast(Toast* toast);
+
+/**
+ * @brief Send an arbitrary OS-native notification with the given title and body.
+ *
+ * Requires notification_init() to have been called first. No-op on non-Windows.
+ *
+ * @param title Notification title text.
+ * @param body  Notification body text.
+ */
+void notification_show(const char* title, const char* body);

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -1,12 +1,39 @@
+/**
+ * @file notification_service.h
+ * @brief OS-native notification delivery for in-game toast events.
+ *
+ * Bridges the game's Toast system to platform notification APIs (Windows toast
+ * notifications via WinRT). Resolves IL2CPP LanguageManager methods at init
+ * time to localize toast text, then formats and delivers notifications for
+ * user-configured notification types.
+ *
+ * Canonical config model:
+ * - `[notifications]` selects which events should produce OS notifications.
+ * - `[ui].disabled_banner_types` only suppresses in-game banner display.
+ * - Legacy `[ui]` notification allowlists are migration-only compatibility.
+ */
 #pragma once
 
 struct Toast;
 
-// Initialize the notification service (resolve IL2CPP methods, init platform).
-// Call once during InstallToastBannerHooks().
+/**
+ * @brief One-time initialization: resolve IL2CPP methods and init the platform.
+ *
+ * Must be called once during InstallToastBannerHooks(). Resolves
+ * LanguageManager::Localize(out string, LocaleTextContext) for text
+ * localization and initializes WinRT on Windows.
+ */
 void notification_init();
 
-// Called from toast hooks — checks config, formats, and delivers notification.
+/**
+ * @brief Process a game toast for potential OS notification delivery.
+ *
+ * Checks the toast state against the unified `[notifications]` config,
+ * builds a human-readable body (battle data or localized text), and delivers
+ * an OS-native notification if the toast type matches.
+ *
+ * @param toast The game Toast object from the hooked banner display method.
+ */
 void notification_handle_toast(Toast* toast);
 
 /**

--- a/mods/src/patches/parts/disable_banners.cc
+++ b/mods/src/patches/parts/disable_banners.cc
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "errormsg.h"
+#include "patches/notification_service.h"
 
 #include <il2cpp/il2cpp_helper.h>
 #include <prime/Toast.h>
@@ -11,6 +12,8 @@ struct ToastObserver {
 
 void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast *toast)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -21,6 +24,8 @@ void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast 
 
 void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_this, Toast *toast, uintptr_t cmpAction)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -31,6 +36,8 @@ void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_thi
 
 void InstallToastBannerHooks()
 {
+  notification_init();
+
   if (auto helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "ToastObserver");
       !helper.isValidHelper()) {
     ErrorMsg::MissingHelper("HUD", "ToastObserver");

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -22,25 +22,6 @@
 
 static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
 
-static const char* fleet_bar_state_str(FleetState state)
-{
-  switch (state) {
-    case FleetState::Unknown:      return "Unknown";
-    case FleetState::IdleInSpace:  return "IdleInSpace";
-    case FleetState::Docked:       return "Docked";
-    case FleetState::Mining:       return "Mining";
-    case FleetState::Destroyed:    return "Destroyed";
-    case FleetState::TieringUp:    return "TieringUp";
-    case FleetState::Repairing:    return "Repairing";
-    case FleetState::Battling:     return "Battling";
-    case FleetState::WarpCharging: return "WarpCharging";
-    case FleetState::Warping:      return "Warping";
-    case FleetState::Impulsing:    return "Impulsing";
-    case FleetState::Capturing:    return "Capturing";
-    default:                       return "Composite";
-  }
-}
-
 static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
 {
   auto* hull = fleet ? fleet->Hull : nullptr;
@@ -86,10 +67,6 @@ static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::strin
     spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
     return;
   }
-
-  if (oldState == FleetState::Warping && newState == FleetState::Docked) {
-    spdlog::info("[FleetBar] DOCKED_AFTER_WARP id={} ship='{}'", fleetId, shipName);
-  }
 }
 
 static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
@@ -101,14 +78,7 @@ static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
     auto shipName     = fleet_bar_ship_name(fleet);
 
     auto it = s_fleet_bar_states.find(fleetId);
-    if (it == s_fleet_bar_states.end()) {
-      spdlog::info("[FleetBar] SetWidgetData snapshot id={} ship='{}' state={}({})",
-                   fleetId, shipName, fleet_bar_state_str(currentState), (int)currentState);
-    } else if (it->second != currentState) {
-      spdlog::info("[FleetBar] SetWidgetData state id={} ship='{}' {}({}) -> {}({})",
-                   fleetId, shipName,
-                   fleet_bar_state_str(it->second), (int)it->second,
-                   fleet_bar_state_str(currentState), (int)currentState);
+    if (it != s_fleet_bar_states.end() && it->second != currentState) {
       maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
     }
 

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -58,13 +58,8 @@ static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::strin
 {
   if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
     auto body = "Your " + shipName + " has arrived in-system";
-    spdlog::info("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
+    spdlog::debug("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
     notification_show("Fleet Arrived", body.c_str());
-    return;
-  }
-
-  if (oldState == FleetState::Impulsing && newState == FleetState::IdleInSpace) {
-    spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
     return;
   }
 }

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -1,0 +1,138 @@
+/**
+ * @file fleet_arrival.cc
+ * @brief Fleet arrival detection driven by the bottom fleet bar state widgets.
+ *
+ * Hooks FleetStateWidget::SetWidgetData and watches FleetPlayerData state
+ * transitions. The most useful arrival signal is Warping -> Impulsing, which
+ * means the ship has dropped out of warp and entered the destination system.
+ */
+#include "errormsg.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <spud/detour.h>
+
+#include <patches/notification_service.h>
+#include <prime/FleetPlayerData.h>
+
+#include <spdlog/spdlog.h>
+#include <str_utils.h>
+
+#include <string_view>
+#include <unordered_map>
+
+static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
+
+static const char* fleet_bar_state_str(FleetState state)
+{
+  switch (state) {
+    case FleetState::Unknown:      return "Unknown";
+    case FleetState::IdleInSpace:  return "IdleInSpace";
+    case FleetState::Docked:       return "Docked";
+    case FleetState::Mining:       return "Mining";
+    case FleetState::Destroyed:    return "Destroyed";
+    case FleetState::TieringUp:    return "TieringUp";
+    case FleetState::Repairing:    return "Repairing";
+    case FleetState::Battling:     return "Battling";
+    case FleetState::WarpCharging: return "WarpCharging";
+    case FleetState::Warping:      return "Warping";
+    case FleetState::Impulsing:    return "Impulsing";
+    case FleetState::Capturing:    return "Capturing";
+    default:                       return "Composite";
+  }
+}
+
+static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
+{
+  auto* hull = fleet ? fleet->Hull : nullptr;
+  auto  name = (hull && hull->Name) ? to_string(hull->Name) : std::string{"?"};
+
+  constexpr std::string_view live_suffix = "_LIVE";
+  if (name.size() >= live_suffix.size() &&
+      name.compare(name.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
+    name.erase(name.size() - live_suffix.size());
+  }
+
+  for (auto& ch : name) {
+    if (ch == '_') {
+      ch = ' ';
+    }
+  }
+
+  return name;
+}
+
+static FleetPlayerData* fleet_bar_widget_context(void* self)
+{
+  if (!self) {
+    return nullptr;
+  }
+
+  auto helper      = IL2CppClassHelper{((Il2CppObject*)self)->klass};
+  auto get_context = helper.GetMethod<FleetPlayerData*(void*)>("get_Context", 0);
+  return get_context ? get_context(self) : nullptr;
+}
+
+static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName,
+                                              FleetState oldState, FleetState newState)
+{
+  if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
+    auto body = "Your " + shipName + " has arrived in-system";
+    spdlog::info("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
+    notification_show("Fleet Arrived", body.c_str());
+    return;
+  }
+
+  if (oldState == FleetState::Impulsing && newState == FleetState::IdleInSpace) {
+    spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
+    return;
+  }
+
+  if (oldState == FleetState::Warping && newState == FleetState::Docked) {
+    spdlog::info("[FleetBar] DOCKED_AFTER_WARP id={} ship='{}'", fleetId, shipName);
+  }
+}
+
+static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
+{
+  auto* fleet = fleet_bar_widget_context(self);
+  if (fleet) {
+    auto fleetId      = fleet->Id;
+    auto currentState = fleet->CurrentState;
+    auto shipName     = fleet_bar_ship_name(fleet);
+
+    auto it = s_fleet_bar_states.find(fleetId);
+    if (it == s_fleet_bar_states.end()) {
+      spdlog::info("[FleetBar] SetWidgetData snapshot id={} ship='{}' state={}({})",
+                   fleetId, shipName, fleet_bar_state_str(currentState), (int)currentState);
+    } else if (it->second != currentState) {
+      spdlog::info("[FleetBar] SetWidgetData state id={} ship='{}' {}({}) -> {}({})",
+                   fleetId, shipName,
+                   fleet_bar_state_str(it->second), (int)it->second,
+                   fleet_bar_state_str(currentState), (int)currentState);
+      maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
+    }
+
+    s_fleet_bar_states[fleetId] = currentState;
+  }
+
+  original(self);
+}
+
+void InstallFleetArrivalHooks()
+{
+  notification_init();
+
+  auto fleet_state_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget");
+  if (!fleet_state_widget.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Prime.HUD", "FleetStateWidget");
+    return;
+  }
+
+  auto set_widget_data = fleet_state_widget.GetMethod("SetWidgetData");
+  if (set_widget_data == nullptr) {
+    ErrorMsg::MissingMethod("FleetStateWidget", "SetWidgetData");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(set_widget_data, FleetStateWidget_SetWidgetData_Hook);
+}

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -6,41 +6,17 @@
  * transitions. The most useful arrival signal is Warping -> Impulsing, which
  * means the ship has dropped out of warp and entered the destination system.
  */
+#include "config.h"
 #include "errormsg.h"
 
+#include <patches/fleet_notifications.h>
 #include <il2cpp/il2cpp_helper.h>
+#include <prime/FleetPlayerData.h>
+#include <prime/MiningObjectViewerWidget.h>
+
 #include <spud/detour.h>
 
-#include <patches/notification_service.h>
-#include <prime/FleetPlayerData.h>
-
 #include <spdlog/spdlog.h>
-#include <str_utils.h>
-
-#include <string_view>
-#include <unordered_map>
-
-static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
-
-static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
-{
-  auto* hull = fleet ? fleet->Hull : nullptr;
-  auto  name = (hull && hull->Name) ? to_string(hull->Name) : std::string{"?"};
-
-  constexpr std::string_view live_suffix = "_LIVE";
-  if (name.size() >= live_suffix.size() &&
-      name.compare(name.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
-    name.erase(name.size() - live_suffix.size());
-  }
-
-  for (auto& ch : name) {
-    if (ch == '_') {
-      ch = ' ';
-    }
-  }
-
-  return name;
-}
 
 static FleetPlayerData* fleet_bar_widget_context(void* self)
 {
@@ -53,39 +29,33 @@ static FleetPlayerData* fleet_bar_widget_context(void* self)
   return get_context ? get_context(self) : nullptr;
 }
 
-static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName,
-                                              FleetState oldState, FleetState newState)
-{
-  if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
-    auto body = "Your " + shipName + " has arrived in-system";
-    spdlog::debug("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
-    notification_show("Fleet Arrived", body.c_str());
-    return;
-  }
-}
-
 static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
 {
   auto* fleet = fleet_bar_widget_context(self);
-  if (fleet) {
-    auto fleetId      = fleet->Id;
-    auto currentState = fleet->CurrentState;
-    auto shipName     = fleet_bar_ship_name(fleet);
-
-    auto it = s_fleet_bar_states.find(fleetId);
-    if (it != s_fleet_bar_states.end() && it->second != currentState) {
-      maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
-    }
-
-    s_fleet_bar_states[fleetId] = currentState;
-  }
+  fleet_notifications_observe_fleet_bar(fleet);
 
   original(self);
 }
 
+static void ToastFleetObserver_HandleMiningDepleted_Hook(auto original, void* self, int64_t fleetId)
+{
+  original(self, fleetId);
+  fleet_notifications_observe_node_depleted(fleetId);
+}
+
+static void MiningObjectViewerWidget_UpdateTimerWidget_Hook(auto original, MiningObjectViewerWidget* self,
+                                                            FleetPlayerData* selectedFleet)
+{
+  original(self, selectedFleet);
+
+  auto* timerContext  = self ? self->_miningTimerWidgetContext : nullptr;
+  auto remainingTicks = timerContext ? timerContext->RemainingTime.Ticks : -1;
+  fleet_notifications_observe_mining_timer(selectedFleet, remainingTicks);
+}
+
 void InstallFleetArrivalHooks()
 {
-  notification_init();
+  fleet_notifications_init();
 
   auto fleet_state_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget");
   if (!fleet_state_widget.isValidHelper()) {
@@ -100,4 +70,33 @@ void InstallFleetArrivalHooks()
   }
 
   SPUD_STATIC_DETOUR(set_widget_data, FleetStateWidget_SetWidgetData_Hook);
+
+  auto toast_fleet_observer = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "ToastFleetObserver");
+  if (!toast_fleet_observer.isValidHelper()) {
+    spdlog::warn("[Fleet] ToastFleetObserver helper not found; node depleted notifications disabled");
+    return;
+  }
+
+  auto handle_mining_depleted = toast_fleet_observer.GetMethod("HandleMiningDepleted");
+  if (handle_mining_depleted == nullptr) {
+    spdlog::warn("[Fleet] ToastFleetObserver.HandleMiningDepleted not found; node depleted notifications disabled");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(handle_mining_depleted, ToastFleetObserver_HandleMiningDepleted_Hook);
+
+  auto mining_object_viewer = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.ObjectViewer", "MiningObjectViewerWidget");
+  if (!mining_object_viewer.isValidHelper()) {
+    spdlog::warn("[MiningViewer] MiningObjectViewerWidget helper not found; mining ETA disabled");
+    return;
+  }
+
+  auto update_timer_widget = mining_object_viewer.GetMethod<void(MiningObjectViewerWidget*, FleetPlayerData*)>(
+      "UpdateTimerWidget", 1);
+  if (update_timer_widget == nullptr) {
+    spdlog::warn("[MiningViewer] MiningObjectViewerWidget.UpdateTimerWidget not found; mining ETA disabled");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(update_timer_widget, MiningObjectViewerWidget_UpdateTimerWidget_Hook);
 }

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -35,6 +35,7 @@ void InstallResolutionListFix();
 void InstallTempCrashFixes();
 void InstallSyncPatches();
 void InstallObjectTrackers();
+void InstallFleetArrivalHooks();
 
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
 {
@@ -117,6 +118,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"ResolutionListFix", {InstallResolutionListFix, &cfg.installResolutionListFix}},
       {"SyncPatches", {InstallSyncPatches, &cfg.installSyncPatches}},
       {"ObjectTracker", {InstallObjectTrackers, &cfg.installObjectTracker}},
+        {"FleetArrival", {InstallFleetArrivalHooks, &cfg.installFleetArrivalHooks}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);
 

--- a/mods/src/prime/BattleResultHeader.h
+++ b/mods/src/prime/BattleResultHeader.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+enum class BattleType {
+  Fleet                          = 0,
+  Base                           = 1,
+  PassiveMarauder                = 2,
+  NpcInstantiated                = 3,
+  DockingPoint                   = 4,
+  ActiveMarauder_MarauderInit    = 5,
+  ActiveMarauder_PlayerInit      = 6,
+  ArmadaBase                     = 7,
+  ArmadaMarauder                 = 8,
+  PveDockingPoint                = 9,
+  ArmadaAsb                      = 10,
+  ArmadaMta                      = 11,
+  Hazard                         = 12,
+  PveCuttingBeam                 = 13,
+  PvpCuttingBeam                 = 14,
+  PveChainShot                   = 15,
+  PvpChainShot                   = 16
+};
+
+enum class BattleResultType {
+  Defeat         = 0,
+  Victory        = 1,
+  PartialVictory = 2
+};
+
+enum class FleetDataType {
+  DeployedFleet = 0,
+  Starbase      = 1,
+  Armada        = 2
+};
+
+struct BattleResultHeader {
+public:
+  __declspec(property(get = __get_PlayerShipHullId)) long PlayerShipHullId;
+  __declspec(property(get = __get_EnemyShipHullId)) long EnemyShipHullId;
+
+  Il2CppObject* get_PlayerUserProfile()
+  {
+    static auto prop = get_class_helper().GetProperty("PlayerUserProfile");
+    return prop.GetRaw<Il2CppObject>(this);
+  }
+
+  Il2CppObject* get_EnemyUserProfile()
+  {
+    static auto prop = get_class_helper().GetProperty("EnemyUserProfile");
+    return prop.GetRaw<Il2CppObject>(this);
+  }
+
+  Il2CppObject* get_SpecService()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x18);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "BattleResultHeader");
+    return class_helper;
+  }
+
+public:
+  long __get_PlayerShipHullId()
+  {
+    static auto prop = get_class_helper().GetProperty("PlayerShipHullId");
+    return *prop.Get<long>(this);
+  }
+
+  long __get_EnemyShipHullId()
+  {
+    static auto prop = get_class_helper().GetProperty("EnemyShipHullId");
+    return *prop.Get<long>(this);
+  }
+};

--- a/mods/src/prime/BattleResultHeader.h
+++ b/mods/src/prime/BattleResultHeader.h
@@ -1,7 +1,17 @@
+/**
+ * @file BattleResultHeader.h
+ * @brief Battle result data structures and enumerations.
+ *
+ * Mirrors Digit.PrimeServer.Models.BattleResultHeader and the associated
+ * enums (BattleType, BattleResultType, FleetDataType). Used by the battle-
+ * log mod to extract combatant ship hull IDs and user profiles from combat
+ * reports.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/** @brief Categorises the type of battle (fleet vs. base, PvP vs. PvE, armada, etc.). */
 enum class BattleType {
   Fleet                          = 0,
   Base                           = 1,
@@ -22,18 +32,27 @@ enum class BattleType {
   PvpChainShot                   = 16
 };
 
+/** @brief Outcome of a battle from the player's perspective. */
 enum class BattleResultType {
   Defeat         = 0,
   Victory        = 1,
   PartialVictory = 2
 };
 
+/** @brief Identifies the type of fleet data (deployed fleet, starbase, or armada). */
 enum class FleetDataType {
   DeployedFleet = 0,
   Starbase      = 1,
   Armada        = 2
 };
 
+/**
+ * @brief Header data for a single battle result.
+ *
+ * Contains the player's and enemy's ship hull IDs, user profiles, and
+ * a reference to the SpecService for resolving hull details. Accessed
+ * from combat report screens and battle-log export functionality.
+ */
 struct BattleResultHeader {
 public:
   __declspec(property(get = __get_PlayerShipHullId)) long PlayerShipHullId;

--- a/mods/src/prime/FleetPlayerData.h
+++ b/mods/src/prime/FleetPlayerData.h
@@ -2,6 +2,7 @@
 
 #include "BattleTargetData.h"
 #include "HullSpec.h"
+#include "MiningSlot.h"
 #include "RecallRequirement.h"
 #include "CanRepairRequirement.h"
 
@@ -36,6 +37,8 @@ public:
   __declspec(property(get = __get_PreviousState)) FleetState PreviousState;
   __declspec(property(get = __get_Id)) uint64_t Id;
   __declspec(property(get = __get_Hull)) HullSpec* Hull;
+  __declspec(property(get = __get_MiningData)) MiningSlot* MiningData;
+  __declspec(property(get = __get_CargoResourceFillLevel)) float CargoResourceFillLevel;
   __declspec(property(get = __get_Address)) void* Address;
   __declspec(property(get = __get_RecallRequirements)) RecallRequirement* RecallRequirements;
   __declspec(property(get = __get_CanRepairRequirement)) CanRepairRequirement* CanRepairRequirements;
@@ -54,6 +57,20 @@ public:
     static auto field = get_class_helper().GetProperty("Hull");
     return field.GetRaw<HullSpec>(this);
   }
+
+  MiningSlot* __get_MiningData()
+  {
+    static auto field = get_class_helper().GetProperty("MiningData");
+    return field.GetRaw<MiningSlot>(this);
+  }
+
+  float __get_CargoResourceFillLevel()
+  {
+    static auto field = get_class_helper().GetProperty("CargoResourceFillLevel");
+    auto* value = field.Get<float>(this);
+    return value ? *value : -1.0f;
+  }
+
   void* __get_Address()
   {
     static auto field = get_class_helper().GetProperty("Address");

--- a/mods/src/prime/HullSpec.h
+++ b/mods/src/prime/HullSpec.h
@@ -15,6 +15,7 @@ enum class HullType {
 struct HullSpec {
 public:
   __declspec(property(get = __get_Id)) long Id;
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
   __declspec(property(get = __get_Type)) HullType Type;
 
 private:
@@ -32,9 +33,15 @@ public:
     return *(long*)((char*)this + field);
   }
 
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+
   HullType __get_Type()
   {
-    static auto field = get_class_helper().GetProperty("Type");
-    return *field.Get<HullType>(this);
+    static auto prop = get_class_helper().GetProperty("Type");
+    return *prop.Get<HullType>(this);
   }
 };

--- a/mods/src/prime/HullSpec.h
+++ b/mods/src/prime/HullSpec.h
@@ -1,7 +1,16 @@
+/**
+ * @file HullSpec.h
+ * @brief Ship hull specification data.
+ *
+ * Mirrors Digit.PrimeServer.Models.HullSpec. Each ship type in the game
+ * has a HullSpec describing its ID, display name, and hull classification
+ * (destroyer, survey, explorer, etc.).
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/** @brief Ship hull classification. */
 enum class HullType {
   Any          = -1,
   Destroyer    = 0,
@@ -12,6 +21,12 @@ enum class HullType {
   ArmadaTarget = 5
 };
 
+/**
+ * @brief Specification data for a single ship hull type.
+ *
+ * Provides the hull's numeric ID (matches server data), localised display
+ * name, and classification type. Obtained via SpecService::GetHull().
+ */
 struct HullSpec {
 public:
   __declspec(property(get = __get_Id)) long Id;

--- a/mods/src/prime/MiningObjectViewerWidget.h
+++ b/mods/src/prime/MiningObjectViewerWidget.h
@@ -7,6 +7,7 @@
 #include "NavigationInteractionUIContext.h"
 #include "ObjectViewerBaseWidget.h"
 #include "ScanEngageButtonsWidget.h"
+#include "TimerDataContext.h"
 
 enum OccupiedState // TypeDefIndex: 12900
 {
@@ -19,6 +20,7 @@ struct MiningObjectViewerWidget : public ObjectViewerBaseWidget<MiningObjectView
 public:
   __declspec(property(get = __get__occupiedState)) OccupiedState _occupiedState;
   __declspec(property(get = __get__scanEngageButtonsWidget)) ScanEngageButtonsWidget* _scanEngageButtonsWidget;
+  __declspec(property(get = __get__miningTimerWidgetContext)) TimerDataContext* _miningTimerWidgetContext;
 
   void MineClicked()
   {
@@ -47,5 +49,11 @@ public:
   {
     static auto field = get_class_helper().GetField("_scanEngageButtonsWidget").offset();
     return *(ScanEngageButtonsWidget**)((char*)this + field);
+  }
+
+  TimerDataContext* __get__miningTimerWidgetContext()
+  {
+    static auto field = get_class_helper().GetField("_miningTimerWidgetContext").offset();
+    return *(TimerDataContext**)((char*)this + field);
   }
 };

--- a/mods/src/prime/MiningSlot.h
+++ b/mods/src/prime/MiningSlot.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "TimeSpan.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct MiningNodeParams {
+public:
+  __declspec(property(get = __get_Amount)) int64_t Amount;
+  __declspec(property(get = __get_ResourceID)) int64_t ResourceID;
+  __declspec(property(get = __get_Rate)) int64_t Rate;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "MiningNodeParams");
+    return class_helper;
+  }
+
+public:
+  int64_t __get_Amount()
+  {
+    static auto field = get_class_helper().GetProperty("Amount");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  int64_t __get_ResourceID()
+  {
+    static auto field = get_class_helper().GetProperty("ResourceID");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  int64_t __get_Rate()
+  {
+    static auto field = get_class_helper().GetProperty("Rate");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+};
+
+struct MiningSlot {
+public:
+  __declspec(property(get = __get_PointData)) MiningNodeParams* PointData;
+  __declspec(property(get = __get_ResourceId)) int64_t ResourceId;
+  __declspec(property(get = __get_PerHourRate)) int64_t PerHourRate;
+  __declspec(property(get = __get_RemainingTime)) TimeSpan RemainingTime;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "MiningSlot");
+    return class_helper;
+  }
+
+public:
+  MiningNodeParams* __get_PointData()
+  {
+    static auto field = get_class_helper().GetProperty("PointData");
+    return field.GetRaw<MiningNodeParams>(this);
+  }
+
+  int64_t __get_ResourceId()
+  {
+    static auto field = get_class_helper().GetProperty("ResourceId");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  int64_t __get_PerHourRate()
+  {
+    static auto field = get_class_helper().GetProperty("PerHourRate");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  TimeSpan __get_RemainingTime()
+  {
+    static auto field = get_class_helper().GetProperty("RemainingTime");
+    auto* value = field.Get<TimeSpan>(this);
+    return value ? *value : TimeSpan{};
+  }
+};

--- a/mods/src/prime/ResourceSpec.h
+++ b/mods/src/prime/ResourceSpec.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct ResourceSpec {
+public:
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "ResourceSpec");
+    return class_helper;
+  }
+
+public:
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetProperty("Name");
+    return field.GetRaw<Il2CppString>(this);
+  }
+};

--- a/mods/src/prime/SpecManager.h
+++ b/mods/src/prime/SpecManager.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "MonoSingleton.h"
+#include "ResourceSpec.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct SpecManager : MonoSingleton<SpecManager> {
+  friend struct MonoSingleton<SpecManager>;
+
+public:
+  ResourceSpec* GetResourceSpec(int64_t id)
+  {
+    static auto method = get_class_helper().GetMethod<ResourceSpec*(SpecManager*, int64_t)>("GetResourceSpec");
+    static auto warn   = true;
+
+    if (method) {
+      return method(this, id);
+    }
+
+    if (warn) {
+      warn = false;
+      ErrorMsg::MissingMethod("SpecManager", "GetResourceSpec");
+    }
+
+    return nullptr;
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Navigation.Managers", "SpecManager");
+    return class_helper;
+  }
+};

--- a/mods/src/prime/SpecService.h
+++ b/mods/src/prime/SpecService.h
@@ -1,8 +1,22 @@
+/**
+ * @file SpecService.h
+ * @brief Game data specification lookup service.
+ *
+ * Mirrors Digit.PrimeServer.Services.SpecService. Acts as a registry
+ * for static game data specifications (ship hulls, etc.). Mod code uses
+ * this to resolve numeric IDs into rich spec objects.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 #include "HullSpec.h"
 
+/**
+ * @brief Service for looking up static game data specifications.
+ *
+ * Currently exposes GetHull() to resolve a hull ID to its HullSpec.
+ * The service instance is typically obtained from the game's service registry.
+ */
 struct SpecService {
 public:
   HullSpec* GetHull(long hullId)

--- a/mods/src/prime/SpecService.h
+++ b/mods/src/prime/SpecService.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+#include "HullSpec.h"
+
+struct SpecService {
+public:
+  HullSpec* GetHull(long hullId)
+  {
+    static auto method =
+        get_class_helper().GetMethod<HullSpec*(SpecService*, long)>("GetHull");
+    return method(this, hullId);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Services", "SpecService");
+    return class_helper;
+  }
+};

--- a/mods/src/prime/TimeSpan.h
+++ b/mods/src/prime/TimeSpan.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+struct TimeSpan {
+public:
+  __declspec(property(get = __get_Ticks)) int64_t Ticks;
+
+  int64_t __get_Ticks() const
+  {
+    return ticks;
+  }
+
+  double TotalSeconds() const
+  {
+    return static_cast<double>(ticks) / 10000000.0;
+  }
+
+private:
+  int64_t ticks = 0;
+};

--- a/mods/src/prime/TimerDataContext.h
+++ b/mods/src/prime/TimerDataContext.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "TimeSpan.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct TimerDataContext {
+public:
+  __declspec(property(get = __get_RemainingTime)) TimeSpan RemainingTime;
+  __declspec(property(get = __get_TimerTypeValue)) int TimerTypeValue;
+  __declspec(property(get = __get_TimerStateValue)) int TimerStateValue;
+  __declspec(property(get = __get_ShowTimerLabel)) bool ShowTimerLabel;
+
+  TimeSpan __get_RemainingTime()
+  {
+    auto helper = IL2CppClassHelper{((Il2CppObject*)this)->klass};
+    auto field  = helper.GetProperty("RemainingTime");
+    auto* value = field.Get<TimeSpan>(this);
+    return value ? *value : TimeSpan{};
+  }
+
+  int __get_TimerTypeValue()
+  {
+    auto helper = IL2CppClassHelper{((Il2CppObject*)this)->klass};
+    auto field  = helper.GetProperty("TimerType");
+    auto* value = field.Get<int>(this);
+    return value ? *value : -1;
+  }
+
+  int __get_TimerStateValue()
+  {
+    auto helper = IL2CppClassHelper{((Il2CppObject*)this)->klass};
+    auto field  = helper.GetProperty("TimerState");
+    auto* value = field.Get<int>(this);
+    return value ? *value : -1;
+  }
+
+  bool __get_ShowTimerLabel()
+  {
+    auto helper = IL2CppClassHelper{((Il2CppObject*)this)->klass};
+    auto field  = helper.GetProperty("ShowTimerLabel");
+    auto* value = field.Get<bool>(this);
+    return value ? *value : false;
+  }
+};

--- a/mods/src/prime/Toast.h
+++ b/mods/src/prime/Toast.h
@@ -50,6 +50,16 @@ enum ToastState {
 
 struct Toast {
 public:
+  void* get_TextLocaleTextContext()
+  {
+    return *reinterpret_cast<void**>(reinterpret_cast<char*>(this) + 0x20);
+  }
+
+  Il2CppObject* get_Data()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x38);
+  }
+
   int get_State()
   {
     static auto prop = get_class_helper().GetProperty("State");

--- a/mods/src/prime/Toast.h
+++ b/mods/src/prime/Toast.h
@@ -1,7 +1,15 @@
+/**
+ * @file Toast.h
+ * @brief Toast notification data and state enumeration.
+ *
+ * Mirrors Digit.Prime.HUD.Toast — the in-game popup notifications for
+ * battles, faction events, armada status, territory capture, etc.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/** @brief Identifies the visual style / category of a toast notification. */
 enum ToastState {
   Standard                  = 0,
   FactionWarning            = 1,
@@ -48,6 +56,12 @@ enum ToastState {
   SurgeTimeLeft             = 43,
 };
 
+/**
+ * @brief A single toast notification displayed in the HUD.
+ *
+ * Provides access to the notification's locale text context, attached data
+ * payload, and display state (e.g. victory, defeat, incoming attack).
+ */
 struct Toast {
 public:
   void* get_TextLocaleTextContext()

--- a/mods/src/prime/UserProfile.h
+++ b/mods/src/prime/UserProfile.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct UserProfile {
+public:
+  __declspec(property(get = __get_LocaId)) long LocaId;
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "UserProfile");
+    return class_helper;
+  }
+
+public:
+  long __get_LocaId()
+  {
+    static auto field = get_class_helper().GetField("_locaId").offset();
+    return *(long*)((char*)this + field);
+  }
+
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+};

--- a/mods/src/prime/UserProfile.h
+++ b/mods/src/prime/UserProfile.h
@@ -1,7 +1,20 @@
+/**
+ * @file UserProfile.h
+ * @brief Player profile data.
+ *
+ * Mirrors Digit.PrimeServer.Models.UserProfile. Provides the player's
+ * location ID and display name, used in battle reports and UI displays.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/**
+ * @brief Profile data for a game player.
+ *
+ * Contains the player's server-side location ID and their display name.
+ * Typically retrieved from BattleResultHeader or other combat data.
+ */
 struct UserProfile {
 public:
   __declspec(property(get = __get_LocaId)) long LocaId;

--- a/mods/src/testable_functions.cc
+++ b/mods/src/testable_functions.cc
@@ -1,0 +1,258 @@
+// Testable pure functions — implementations extracted from
+// notification_service.cc and battle_notify_parser.cc so they can be
+// compiled and tested without IL2CPP or game dependencies.
+
+#include "testable_functions.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <sstream>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Toast state enum values (mirrored from prime/Toast.h's ToastState enum
+// so this file doesn't need the IL2CPP include chain)
+// ---------------------------------------------------------------------------
+enum ToastStateValues {
+  TS_Standard                  = 0,
+  TS_FactionWarning            = 1,
+  TS_FactionLevelUp            = 2,
+  TS_FactionLevelDown          = 3,
+  TS_FactionDiscovered         = 4,
+  TS_IncomingAttack            = 5,
+  TS_IncomingAttackFaction     = 6,
+  TS_FleetBattle               = 7,
+  TS_StationBattle             = 8,
+  TS_StationVictory            = 9,
+  TS_Victory                   = 10,
+  TS_Defeat                    = 11,
+  TS_StationDefeat             = 12,
+  TS_Tournament                = 14,
+  TS_ArmadaCreated             = 15,
+  TS_ArmadaCanceled            = 16,
+  TS_ArmadaIncomingAttack      = 17,
+  TS_ArmadaBattleWon           = 18,
+  TS_ArmadaBattleLost          = 19,
+  TS_DiplomacyUpdated          = 20,
+  TS_JoinedTakeover            = 21,
+  TS_CompetitorJoinedTakeover  = 22,
+  TS_AbandonedTerritory        = 23,
+  TS_TakeoverVictory           = 24,
+  TS_TakeoverDefeat            = 25,
+  TS_TreasuryProgress          = 26,
+  TS_TreasuryFull              = 27,
+  TS_Achievement               = 28,
+  TS_AssaultVictory            = 29,
+  TS_AssaultDefeat             = 30,
+  TS_ChallengeComplete         = 31,
+  TS_ChallengeFailed           = 32,
+  TS_StrikeHit                 = 33,
+  TS_StrikeDefeat              = 34,
+  TS_WarchestProgress          = 35,
+  TS_WarchestFull              = 36,
+  TS_PartialVictory            = 37,
+  TS_ArenaTimeLeft             = 38,
+  TS_ChainedEventScored        = 39,
+  TS_FleetPresetApplied        = 40,
+  TS_SurgeWarmUpEnded          = 41,
+  TS_SurgeHostileGroupDefeated = 42,
+  TS_SurgeTimeLeft             = 43,
+};
+
+// ---------------------------------------------------------------------------
+// toast_state_title
+// ---------------------------------------------------------------------------
+const char* toast_state_title(int state)
+{
+  switch (state) {
+    case TS_Victory:                   return "Victory!";
+    case TS_Defeat:                    return "Defeat";
+    case TS_PartialVictory:            return "Partial Victory";
+    case TS_StationVictory:            return "Station Victory!";
+    case TS_StationDefeat:             return "Station Defeat";
+    case TS_StationBattle:             return "Station Under Attack!";
+    case TS_IncomingAttack:            return "Incoming Attack!";
+    case TS_IncomingAttackFaction:     return "Incoming Faction Attack!";
+    case TS_FleetBattle:               return "Fleet Battle";
+    case TS_ArmadaBattleWon:           return "Armada Victory!";
+    case TS_ArmadaBattleLost:          return "Armada Defeated";
+    case TS_ArmadaCreated:             return "Armada Created";
+    case TS_ArmadaCanceled:            return "Armada Canceled";
+    case TS_ArmadaIncomingAttack:      return "Armada Under Attack!";
+    case TS_AssaultVictory:            return "Assault Victory!";
+    case TS_AssaultDefeat:             return "Assault Defeat";
+    case TS_Tournament:                return "Event Progress";
+    case TS_ChainedEventScored:        return "Event Progress";
+    case TS_Achievement:               return "Achievement";
+    case TS_ChallengeComplete:         return "Challenge Complete";
+    case TS_ChallengeFailed:           return "Challenge Failed";
+    case TS_TakeoverVictory:           return "Takeover Victory!";
+    case TS_TakeoverDefeat:            return "Takeover Defeat";
+    case TS_TreasuryProgress:          return "Treasury Progress";
+    case TS_TreasuryFull:              return "Treasury Full";
+    case TS_WarchestProgress:          return "Warchest Progress";
+    case TS_WarchestFull:              return "Warchest Full";
+    case TS_FactionLevelUp:            return "Faction Level Up";
+    case TS_FactionLevelDown:          return "Faction Level Down";
+    case TS_FactionDiscovered:         return "Faction Discovered";
+    case TS_FactionWarning:            return "Faction Warning";
+    case TS_DiplomacyUpdated:          return "Diplomacy Updated";
+    case TS_StrikeHit:                 return "Strike Hit";
+    case TS_StrikeDefeat:              return "Strike Defeat";
+    case TS_SurgeWarmUpEnded:          return "Surge Started";
+    case TS_SurgeHostileGroupDefeated: return "Surge Hostiles Defeated";
+    case TS_SurgeTimeLeft:             return "Surge Time Warning";
+    case TS_ArenaTimeLeft:             return "Arena Time Warning";
+    case TS_FleetPresetApplied:        return "Fleet Preset Applied";
+    default:                           return nullptr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// strip_unity_rich_text
+// ---------------------------------------------------------------------------
+std::string strip_unity_rich_text(const std::string& s)
+{
+  std::string result;
+  result.reserve(s.size());
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '<') {
+      auto end = s.find('>', i);
+      if (end != std::string::npos) { i = end + 1; continue; }
+    }
+    result += s[i++];
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// parse_hull_key
+// ---------------------------------------------------------------------------
+std::string parse_hull_key(const std::string& key)
+{
+  auto s = key;
+
+  if (s.size() > 5 && s.ends_with("_LIVE"))
+    s = s.substr(0, s.size() - 5);
+
+  if (s.starts_with("Hull_"))
+    s = s.substr(5);
+
+  for (auto& c : s)
+    if (c == '_') c = ' ';
+
+  if (s.size() >= 2 && s[0] == 'L' && std::isdigit(s[1])) {
+    auto space = s.find(' ');
+    auto lvl   = s.substr(1, space == std::string::npos ? std::string::npos : space - 1);
+    auto rest  = space == std::string::npos ? "" : s.substr(space);
+    s = "Lv." + lvl + rest;
+  }
+
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Fleet notification formatting
+// ---------------------------------------------------------------------------
+std::string format_duration_short(int64_t seconds)
+{
+  if (seconds <= 0) return "";
+
+  auto hourPart   = seconds / 3600;
+  auto minutePart = (seconds % 3600) / 60;
+  auto secondPart = seconds % 60;
+
+  std::ostringstream out;
+  if (hourPart > 0) {
+    out << hourPart << "h";
+    if (minutePart > 0) out << ' ' << minutePart << "m";
+    return out.str();
+  }
+
+  if (minutePart > 0) {
+    out << minutePart << "m";
+    if (secondPart > 0) out << ' ' << secondPart << "s";
+    return out.str();
+  }
+
+  out << secondPart << "s";
+  return out.str();
+}
+
+std::string format_cargo_fill_text(float fillLevel)
+{
+  if (!std::isfinite(fillLevel) || fillLevel < 0.0f) return "";
+
+  auto percent = static_cast<int>(std::lround(std::clamp(fillLevel, 0.0f, 1.0f) * 100.0f));
+  return "Current Cargo: " + std::to_string(percent) + "%";
+}
+
+std::string format_started_mining_title(const std::string& shipName, const std::string& resourceName)
+{
+  auto subject = shipName.empty() ? std::string{"Fleet"} : shipName;
+  auto title   = subject + " started mining";
+
+  if (!resourceName.empty()) {
+    title += " " + resourceName;
+  }
+
+  return title;
+}
+
+std::string format_started_mining_body(const std::string& etaText, const std::string& cargoText)
+{
+  std::string body;
+
+  if (!etaText.empty()) {
+    body += "ETA " + etaText;
+  }
+
+  if (!cargoText.empty()) {
+    if (!body.empty()) {
+      body += "\n";
+    }
+    body += cargoText;
+  }
+
+  return body;
+}
+
+std::string format_node_depleted_body(const std::string& shipName, const std::string& resourceName,
+                                      const std::string& cargoText)
+{
+  auto subject = (shipName.empty() || shipName == "?") ? std::string{"Fleet"} : shipName;
+  auto body    = subject + " depleted its";
+
+  if (!resourceName.empty()) {
+    body += " " + resourceName + " node.";
+  } else {
+    body += " node.";
+  }
+
+  if (!cargoText.empty()) {
+    body += " " + cargoText + ".";
+  }
+
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// BattleSummaryPreview::format_body
+// ---------------------------------------------------------------------------
+std::string BattleSummaryPreview::format_body() const
+{
+  auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
+    if (name.empty()) return "";
+    if (ship.empty()) return name;
+    return name + " (" + ship + ")";
+  };
+
+  auto left  = format_side(playerName, playerShip);
+  auto right = format_side(enemyName, enemyShip);
+  if (left.empty() && right.empty()) return "";
+  if (left.empty()) return right;
+  if (right.empty()) return left;
+  return left + " vs " + right;
+}

--- a/mods/src/testable_functions.h
+++ b/mods/src/testable_functions.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// Testable pure functions extracted from notification_service.cc and
+// battle_notify_parser.cc.  No IL2CPP, no platform, no game memory.
+
+#include <cstdint>
+#include <string>
+
+// Toast state → human-readable title.  Returns nullptr for unknown states.
+const char* toast_state_title(int state);
+
+// Strip Unity rich text tags: <color=#FF0000>, <b>, </size>, etc.
+std::string strip_unity_rich_text(const std::string& s);
+
+// Hull name key → display name:
+//   "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
+std::string parse_hull_key(const std::string& key);
+
+// Fleet notification text helpers.
+std::string format_duration_short(int64_t seconds);
+std::string format_cargo_fill_text(float fillLevel);
+std::string format_started_mining_title(const std::string& shipName, const std::string& resourceName);
+std::string format_started_mining_body(const std::string& etaText, const std::string& cargoText);
+std::string format_node_depleted_body(const std::string& shipName, const std::string& resourceName,
+                                      const std::string& cargoText);
+
+// Battle summary formatting
+struct BattleSummaryPreview {
+  std::string playerName;
+  std::string enemyName;
+  std::string playerShip;
+  std::string enemyShip;
+
+  std::string format_body() const;
+};


### PR DESCRIPTION
## Reviewer Quick Path

This is a draft reference PR, not the preferred merge review. Use it only to inspect the original combined notification branch.

For review, use the split upstream PRs:

1. `#170` `feat: add notification foundation and battle text`
2. `#171` `feat: add fleet alerts and notification policy`
3. `#172` `feat: finish notification semantics`

Source-branch compare links for incremental review:

- `138B`: https://github.com/Guffawaffle/stfc-mod/compare/restack/pr138a-notification-foundation...restack/pr138b-fleet-alerts-policy
- `138C`: https://github.com/Guffawaffle/stfc-mod/compare/restack/pr138b-fleet-alerts-policy...restack/pr138c-notification-semantics

## Status

This PR is the original monolithic notification branch. It is kept open as a reference / precursor branch, not as the preferred upstream review unit.

The feature direction is still good:

- OS-level notifications
- richer battle notification text
- fleet-derived alerts
- clearer notification policy ownership
- repair-complete semantics

The reason for the split is reviewability, not product direction. The smaller split PRs should be reviewed instead.

## Why The Split Review Is Preferred

This branch mixes several review topics in one place:

- notification delivery seam
- battle toast parsing and text quality
- fleet arrival and fleet-derived alerts
- notification config/policy reshaping
- placeholder correctness fixes
- repair-complete semantics

The split branches keep those concerns in smaller, more reviewable units while preserving the overall direction.

## Validation Note

This reference PR is not being presented as the validated merge unit for the restack.

Each split PR carries its own explicit validation notes instead.