### PR TITLE
fix: pin protobuf abseil dep to 20260107.1 to match inline namespace

### DIFF
--- a/xmake-packages/packages/p/protobuf/xmake.lua
+++ b/xmake-packages/packages/p/protobuf/xmake.lua
@@ -11,7 +11,7 @@ add_deps("cmake")
 
 on_load(function (package)
 -- pin abseil to the version in https://github.com/protocolbuffers/protobuf/blob/main/protobuf_deps.bzl when you update protobuf
-    package:add("deps", "abseil 20250512.1")
+    package:add("deps", "abseil 20260107.1")
 
     if package:is_plat("windows") then
         package:add("links", "libprotoc", "libprotobuf", "utf8_range", "utf8_validity", "libutf8_range", "libutf8_validity")


### PR DESCRIPTION
protobuf 32.1 uses absl::lts_20260107 inline namespace. Using abseil 20250512.1 (lts_20250512) causes 127 unresolved external linker errors because the mangled symbol names don't match.