### PR TITLE
Align local macOS packaging with CI

### DIFF
--- a/scripts/create-mac-dmg.sh
+++ b/scripts/create-mac-dmg.sh
@@ -7,11 +7,11 @@ ARCH=arm64
 
 xmake clean
 # Build the arm64 version
-xmake f -y -p macosx -a "arm64" -m $CONFIG --target_minver=15.4
+xmake f -y -p macosx -a "arm64" -m $CONFIG --target_minver=13.5
 xmake
 
 # Build the x86_64 version
-xmake f -y -p macosx -a "x86_64" -m $CONFIG --target_minver=15.4
+xmake f -y -p macosx -a "x86_64" -m $CONFIG --target_minver=13.5
 xmake
 
 # Rebuild the package app bundle after switching architectures so xcode.xcassets

--- a/scripts/mac-build-test-debug.sh
+++ b/scripts/mac-build-test-debug.sh
@@ -216,20 +216,27 @@ package_app_bundle() {
         exit 1
     fi
 
+    local icon_path="${PROJECT_ROOT}/assets/launcher.icns"
+    if [[ ! -f "$icon_path" ]]; then
+        print_error "Launcher icon not found at: $icon_path"
+        exit 1
+    fi
+
+    local info_plist_path="${PROJECT_ROOT}/macos-launcher/src/Info.plist"
+    if [[ ! -f "$info_plist_path" ]]; then
+        print_error "Generated Info.plist not found at: $info_plist_path"
+        print_info "Run the configure/build step so xmake can generate it from Info.plist.template"
+        exit 1
+    fi
+
     rm -rf "$STFC_APP_PATH"
     ditto "$APP_PATH" "$STFC_APP_PATH"
 
     mkdir -p "${STFC_APP_PATH}/Contents/Resources"
     cp "$LOADER_PATH" "${STFC_APP_PATH}/Contents/stfc-community-mod-loader"
     cp "$dylib_path" "${STFC_APP_PATH}/Contents/libstfc-community-mod.dylib"
-
-    if [[ -f "${PROJECT_ROOT}/assets/launcher.icns" ]]; then
-        cp "${PROJECT_ROOT}/assets/launcher.icns" "${STFC_APP_PATH}/Contents/Resources/"
-    fi
-
-    if [[ -f "${PROJECT_ROOT}/macos-launcher/src/Info.plist" ]]; then
-        cp "${PROJECT_ROOT}/macos-launcher/src/Info.plist" "${STFC_APP_PATH}/Contents/"
-    fi
+    cp "$icon_path" "${STFC_APP_PATH}/Contents/Resources/"
+    cp "$info_plist_path" "${STFC_APP_PATH}/Contents/"
 
     print_info "Code signing packaged application..."
     codesign --force --verify --verbose --deep --sign "-" "$STFC_APP_PATH"
@@ -374,7 +381,7 @@ debug_app() {
     local exec_name
     
     if [[ "$USE_LAUNCHER" == true ]]; then
-        executable="${APP_PATH}/Contents/MacOS/macOSLauncher"
+        executable="${STFC_APP_PATH}/Contents/MacOS/macOSLauncher"
         exec_name="Launcher"
     else
         executable="$LOADER_PATH"

--- a/scripts/mac-build-test-debug.sh
+++ b/scripts/mac-build-test-debug.sh
@@ -138,7 +138,7 @@ esac
 BUILD_DIR="${PROJECT_ROOT}/build/macosx/${ARCH}/${BUILD_MODE}"
 APP_PATH="${BUILD_DIR}/macOSLauncher.app"
 LOADER_PATH="${BUILD_DIR}/stfc-community-mod-loader"
-STFC_APP_PATH="${BUILD_DIR}/STFC Community Mod.app"
+PACKAGED_APP_PATH="${BUILD_DIR}/STFC Community Mod.app"
 
 # Configure the project
 configure_project() {
@@ -229,20 +229,20 @@ package_app_bundle() {
         exit 1
     fi
 
-    rm -rf "$STFC_APP_PATH"
-    ditto "$APP_PATH" "$STFC_APP_PATH"
+    rm -rf "$PACKAGED_APP_PATH"
+    ditto "$APP_PATH" "$PACKAGED_APP_PATH"
 
-    mkdir -p "${STFC_APP_PATH}/Contents/Resources"
-    cp "$LOADER_PATH" "${STFC_APP_PATH}/Contents/stfc-community-mod-loader"
-    cp "$dylib_path" "${STFC_APP_PATH}/Contents/libstfc-community-mod.dylib"
-    cp "$icon_path" "${STFC_APP_PATH}/Contents/Resources/"
-    cp "$info_plist_path" "${STFC_APP_PATH}/Contents/"
+    mkdir -p "${PACKAGED_APP_PATH}/Contents/Resources"
+    cp "$LOADER_PATH" "${PACKAGED_APP_PATH}/Contents/stfc-community-mod-loader"
+    cp "$dylib_path" "${PACKAGED_APP_PATH}/Contents/libstfc-community-mod.dylib"
+    cp "$icon_path" "${PACKAGED_APP_PATH}/Contents/Resources/"
+    cp "$info_plist_path" "${PACKAGED_APP_PATH}/Contents/"
 
     print_info "Code signing packaged application..."
-    codesign --force --verify --verbose --deep --sign "-" "$STFC_APP_PATH"
-    codesign --verify --deep --strict --verbose=2 "$STFC_APP_PATH"
+    codesign --force --verify --verbose --deep --sign "-" "$PACKAGED_APP_PATH"
+    codesign --verify --deep --strict --verbose=2 "$PACKAGED_APP_PATH"
 
-    print_success "Packaged app prepared at: $STFC_APP_PATH"
+    print_success "Packaged app prepared at: $PACKAGED_APP_PATH"
 }
 
 # Prepare the app bundle for running
@@ -251,18 +251,18 @@ prepare_app() {
         print_info "Preparing launcher application bundle..."
         
         # Check if app was built
-        if [[ ! -d "$STFC_APP_PATH" ]]; then
-            print_warning "Packaged app not found at: $STFC_APP_PATH"
+        if [[ ! -d "$PACKAGED_APP_PATH" ]]; then
+            print_warning "Packaged app not found at: $PACKAGED_APP_PATH"
             package_app_bundle
         fi
 
-        if [[ ! -d "$STFC_APP_PATH" ]]; then
-            print_error "Launcher app not found at: $STFC_APP_PATH"
+        if [[ ! -d "$PACKAGED_APP_PATH" ]]; then
+            print_error "Launcher app not found at: $PACKAGED_APP_PATH"
             print_info "Make sure the launcher was built successfully"
             exit 1
         fi
 
-        print_success "Launcher prepared at: $STFC_APP_PATH"
+        print_success "Launcher prepared at: $PACKAGED_APP_PATH"
     else
         print_info "Preparing loader..."
         
@@ -292,7 +292,7 @@ run_app() {
     if [[ "$USE_LAUNCHER" == true ]]; then
         print_info "Launching application with launcher..."
         print_info "Crash dumps will be generated at: ~/Library/Logs/DiagnosticReports/"
-        open "$STFC_APP_PATH"
+        open "$PACKAGED_APP_PATH"
         
         print_success "Launcher launched"
         print_info "To view logs, use: log stream --predicate 'process == \"macOSLauncher\"' --level debug"
@@ -381,7 +381,7 @@ debug_app() {
     local exec_name
     
     if [[ "$USE_LAUNCHER" == true ]]; then
-        executable="${STFC_APP_PATH}/Contents/MacOS/macOSLauncher"
+        executable="${PACKAGED_APP_PATH}/Contents/MacOS/macOSLauncher"
         exec_name="Launcher"
     else
         executable="$LOADER_PATH"

--- a/scripts/mac-build-test-debug.sh
+++ b/scripts/mac-build-test-debug.sh
@@ -188,6 +188,54 @@ build_project() {
         print_info "Built files:"
         ls -lh "${BUILD_DIR}" | grep -E '\.(app|dylib)$' || true
     fi
+
+    package_app_bundle
+}
+
+# Package the launcher bundle the same way CI does, but keep xmake's
+# macOSLauncher.app in place so local incremental builds still work.
+package_app_bundle() {
+    print_info "Packaging launcher application bundle..."
+
+    if [[ ! -d "$APP_PATH" ]]; then
+        print_error "Launcher app not found at: $APP_PATH"
+        print_info "Make sure the launcher was built successfully"
+        exit 1
+    fi
+
+    if [[ ! -f "$LOADER_PATH" ]]; then
+        print_error "Loader not found at: $LOADER_PATH"
+        print_info "Make sure the loader was built successfully"
+        exit 1
+    fi
+
+    local dylib_path="${BUILD_DIR}/libstfc-community-mod.dylib"
+    if [[ ! -f "$dylib_path" ]]; then
+        print_error "Mod library not found at: $dylib_path"
+        print_info "Make sure the mod library was built successfully"
+        exit 1
+    fi
+
+    rm -rf "$STFC_APP_PATH"
+    ditto "$APP_PATH" "$STFC_APP_PATH"
+
+    mkdir -p "${STFC_APP_PATH}/Contents/Resources"
+    cp "$LOADER_PATH" "${STFC_APP_PATH}/Contents/stfc-community-mod-loader"
+    cp "$dylib_path" "${STFC_APP_PATH}/Contents/libstfc-community-mod.dylib"
+
+    if [[ -f "${PROJECT_ROOT}/assets/launcher.icns" ]]; then
+        cp "${PROJECT_ROOT}/assets/launcher.icns" "${STFC_APP_PATH}/Contents/Resources/"
+    fi
+
+    if [[ -f "${PROJECT_ROOT}/macos-launcher/src/Info.plist" ]]; then
+        cp "${PROJECT_ROOT}/macos-launcher/src/Info.plist" "${STFC_APP_PATH}/Contents/"
+    fi
+
+    print_info "Code signing packaged application..."
+    codesign --force --verify --verbose --deep --sign "-" "$STFC_APP_PATH"
+    codesign --verify --deep --strict --verbose=2 "$STFC_APP_PATH"
+
+    print_success "Packaged app prepared at: $STFC_APP_PATH"
 }
 
 # Prepare the app bundle for running
@@ -196,23 +244,18 @@ prepare_app() {
         print_info "Preparing launcher application bundle..."
         
         # Check if app was built
-        if [[ ! -d "$APP_PATH" ]]; then
-            print_error "Launcher app not found at: $APP_PATH"
+        if [[ ! -d "$STFC_APP_PATH" ]]; then
+            print_warning "Packaged app not found at: $STFC_APP_PATH"
+            package_app_bundle
+        fi
+
+        if [[ ! -d "$STFC_APP_PATH" ]]; then
+            print_error "Launcher app not found at: $STFC_APP_PATH"
             print_info "Make sure the launcher was built successfully"
             exit 1
         fi
-        
-        # Copy icon if it exists
-        if [[ -f "${PROJECT_ROOT}/assets/launcher.icns" ]]; then
-            mkdir -p "${APP_PATH}/Contents/Resources"
-            cp "${PROJECT_ROOT}/assets/launcher.icns" "${APP_PATH}/Contents/Resources/"
-        fi
-        
-        # Sign the app (required for running on macOS)
-        print_info "Code signing launcher application..."
-        codesign --force --deep --sign "-" "$APP_PATH" 2>/dev/null || true
-        
-        print_success "Launcher prepared at: $APP_PATH"
+
+        print_success "Launcher prepared at: $STFC_APP_PATH"
     else
         print_info "Preparing loader..."
         
@@ -242,7 +285,7 @@ run_app() {
     if [[ "$USE_LAUNCHER" == true ]]; then
         print_info "Launching application with launcher..."
         print_info "Crash dumps will be generated at: ~/Library/Logs/DiagnosticReports/"
-        open "$APP_PATH"
+        open "$STFC_APP_PATH"
         
         print_success "Launcher launched"
         print_info "To view logs, use: log stream --predicate 'process == \"macOSLauncher\"' --level debug"


### PR DESCRIPTION
This makes the local macOS build script assemble the same app bundle layout that CI packages.

Why:
- I was testing the macOS launcher locally, but the dev script only launched the raw `macOSLauncher.app` output.
- CI adds the auxiliary loader, injected dylib, generated `Info.plist`, icon, and signs the final `STFC Community Mod.app` bundle.
- Mirroring that locally makes macOS testing closer to the release artifact.

Changes:
- Have `mac-build-test-debug.sh` package and verify `STFC Community Mod.app` after building.
- Keep xmake's `macOSLauncher.app` in place for incremental rebuilds, and copy it to the packaged app instead of moving it.
- Launch the packaged app for launcher runs.
- Match `create-mac-dmg.sh`'s deployment target to CI / plist (`13.5`).

I have a few separate macOS fixes from local testing, but I'm sending them as small focused PRs rather than one large batch. Happy to adjust the script shape if you'd prefer this logic to live elsewhere.
