### PR TITLE
Add local file sync targets

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -454,10 +454,13 @@ verify_ssl = true
 # Local file sync target for debugging/private local archiving.
 # file:// targets write sync data to your computer instead of sending it over the network.
 # A token is not required for file:// targets.
-# Currently supported only on macOS/Linux.
 # Use an absolute local directory path. The directory is created if it does not exist.
+# Data type toggles inherit from [sync] unless they are overridden on the target.
+# On Windows, use a drive-letter file URL such as file:///C:/Users/you/stfc-sync.
 # Data is appended to one JSONL file per sync type, for example inventory.jsonl.
 # Each line is an envelope with type, first_sync, timestamp, and the raw request body string in body.
+# Consumers should parse body as JSON if they want to inspect the payload.
 # Query strings and fragments are not supported.
 # [sync.targets.localfile]
 # url = "file:///Users/you/stfc-sync"
+# inventory = true

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -458,8 +458,7 @@ verify_ssl = true
 # Data type toggles inherit from [sync] unless they are overridden on the target.
 # On Windows, use a drive-letter file URL such as file:///C:/Users/you/stfc-sync.
 # Data is appended to one JSONL file per sync type, for example inventory.jsonl.
-# Each line is an envelope with type, first_sync, timestamp, and the raw request body string in body.
-# Consumers should parse body as JSON if they want to inspect the payload.
+# Each line is the same JSON request body that would be posted to an HTTP sync target.
 # Query strings and fragments are not supported.
 # [sync.targets.localfile]
 # url = "file:///Users/you/stfc-sync"

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -451,6 +451,13 @@ verify_ssl = true
 # The url of the server to send data to
 # url = ""
 
-# Local file sync target for debugging. Token is not required for file:// targets.
+# Local file sync target for debugging/private local archiving.
+# file:// targets write sync data to your computer instead of sending it over the network.
+# A token is not required for file:// targets.
+# Currently supported only on macOS/Linux.
+# Use an absolute local directory path. The directory is created if it does not exist.
+# Data is appended to one JSONL file per sync type, for example inventory.jsonl.
+# Each line is an envelope with type, first_sync, timestamp, and the raw request body string in body.
+# Query strings and fragments are not supported.
 # [sync.targets.localfile]
 # url = "file:///Users/you/stfc-sync"

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -450,3 +450,7 @@ verify_ssl = true
 
 # The url of the server to send data to
 # url = ""
+
+# Local file sync target for debugging. Token is not required for file:// targets.
+# [sync.targets.localfile]
+# url = "file:///Users/you/stfc-sync"

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -339,6 +339,7 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
       auto proxy = values["proxy"].value<std::string>();
 
       if (!url.has_value()) {
+        spdlog::warn("Skipping invalid target [{}]. url must be a string.", target_section);
         continue;
       }
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -82,7 +82,18 @@ bool SyncConfig::enabled(SyncConfig::Type type) const
 
 bool SyncTargetConfig::is_file_target() const
 {
-  return url.starts_with("file://");
+  static constexpr std::string_view scheme = "file://";
+  if (url.size() < scheme.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < scheme.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(url[i])) != std::tolower(static_cast<unsigned char>(scheme[i]))) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 Config::Config()

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -80,6 +80,11 @@ bool SyncConfig::enabled(SyncConfig::Type type) const
   return false;
 }
 
+bool SyncTargetConfig::is_file_target() const
+{
+  return url.starts_with("file://");
+}
+
 Config::Config()
 {
   Load();
@@ -328,26 +333,34 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
     toml::table      parsed_target;
 
     const auto& values = *target_config.as_table();
-    if (values.contains("url") && values.contains("token")) {
+    if (values.contains("url")) {
       auto url   = values["url"].value<std::string>();
       auto token = values["token"].value<std::string>();
       auto proxy = values["proxy"].value<std::string>();
 
-      if (!url.has_value() || !token.has_value()) {
+      if (!url.has_value()) {
         continue;
       }
 
-      target.url        = url.value();
-      target.token      = token.value();
+      target.url = url.value();
+
+      if (!token.has_value() && !target.is_file_target()) {
+        spdlog::warn("Skipping invalid target [{}]. Missing token.", target_section);
+        continue;
+      }
+
+      target.token      = token.value_or("");
       target.proxy      = proxy.value_or(defaults.proxy);
       target.verify_ssl = values["verify_ssl"].value<bool>().value_or(defaults.verify_ssl);
 
       parsed_target.insert("url", target.url);
-      parsed_target.insert("token", target.token);
+      if (token.has_value()) {
+        parsed_target.insert("token", target.token);
+      }
       parsed_target.insert("proxy", target.proxy);
       parsed_target.insert("verify_ssl", target.verify_ssl);
     } else {
-      spdlog::warn("Skipping invalid target [{}]. Missing url or token.", target_section);
+      spdlog::warn("Skipping invalid target [{}]. Missing url.", target_section);
       continue;
     }
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -10,6 +10,7 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <iostream>
 #include <ranges>

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -99,6 +99,8 @@ constexpr std::string operator+(const SyncConfig::Type type, const std::string& 
 class SyncTargetConfig : public SyncConfig
 {
 public:
+  [[nodiscard]] bool is_file_target() const;
+
   std::string url;
   std::string token;
 };

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -288,6 +288,12 @@ static bool decode_file_url_path(std::string_view encoded, std::string& decoded,
 
 static bool parse_file_target_directory(const std::string& url, std::filesystem::path& directory, std::string& error)
 {
+#if _WIN32
+  (void)url;
+  (void)directory;
+  error = "file:// sync targets are currently supported only on macOS/Linux";
+  return false;
+#else
   static constexpr std::string_view scheme = "file://";
 
   if (!url.starts_with(scheme)) {
@@ -322,6 +328,7 @@ static bool parse_file_target_directory(const std::string& url, std::filesystem:
   }
 
   return true;
+#endif
 }
 
 static std::string current_sync_timestamp()
@@ -353,16 +360,11 @@ static void write_file_target_data(const std::string& target_identifier, const S
     return;
   }
 
-  nlohmann::json payload = nlohmann::json::parse(post_data, nullptr, false);
-  if (payload.is_discarded()) {
-    payload = post_data;
-  }
-
   const nlohmann::json envelope{
       {"type", to_string(type)},
       {"first_sync", is_first_sync},
       {"timestamp", current_sync_timestamp()},
-      {"payload", std::move(payload)},
+      {"body", post_data},
   };
 
   std::scoped_lock lk(file_target_mtx);

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -34,11 +34,14 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <ctime>
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <iomanip>
 #include <mutex>
 #include <queue>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -229,6 +232,164 @@ struct TargetWorker {
 
 static std::unordered_map<std::string, std::shared_ptr<TargetWorker>> target_workers;
 static std::mutex target_workers_mtx;
+static std::mutex file_target_mtx;
+
+static int from_hex(const char c)
+{
+  if (c >= '0' && c <= '9') {
+    return c - '0';
+  }
+
+  if (c >= 'a' && c <= 'f') {
+    return c - 'a' + 10;
+  }
+
+  if (c >= 'A' && c <= 'F') {
+    return c - 'A' + 10;
+  }
+
+  return -1;
+}
+
+static bool decode_file_url_path(std::string_view encoded, std::string& decoded, std::string& error)
+{
+  decoded.clear();
+
+  for (size_t i = 0; i < encoded.size(); ++i) {
+    if (encoded[i] != '%') {
+      decoded.push_back(encoded[i]);
+      continue;
+    }
+
+    if (i + 2 >= encoded.size()) {
+      error = "file URL contains incomplete percent encoding";
+      return false;
+    }
+
+    const int high = from_hex(encoded[i + 1]);
+    const int low  = from_hex(encoded[i + 2]);
+    if (high < 0 || low < 0) {
+      error = "file URL contains invalid percent encoding";
+      return false;
+    }
+
+    const char value = static_cast<char>((high << 4) | low);
+    if (value == '\0') {
+      error = "file URL path may not contain NUL";
+      return false;
+    }
+
+    decoded.push_back(value);
+    i += 2;
+  }
+
+  return true;
+}
+
+static bool parse_file_target_directory(const std::string& url, std::filesystem::path& directory, std::string& error)
+{
+  static constexpr std::string_view scheme = "file://";
+
+  if (!url.starts_with(scheme)) {
+    error = "target URL is not a file URL";
+    return false;
+  }
+
+  std::string_view path_part(url.data() + scheme.size(), url.size() - scheme.size());
+  if (path_part.starts_with("localhost/")) {
+    path_part.remove_prefix(std::string_view("localhost").size());
+  }
+
+  if (path_part.empty() || !path_part.starts_with("/")) {
+    error = "file URL must use an absolute local path";
+    return false;
+  }
+
+  if (path_part.find_first_of("?#") != std::string_view::npos) {
+    error = "file URL query strings and fragments are not supported";
+    return false;
+  }
+
+  std::string decoded;
+  if (!decode_file_url_path(path_part, decoded, error)) {
+    return false;
+  }
+
+  directory = std::filesystem::path(decoded);
+  if (!directory.is_absolute()) {
+    error = "file URL must resolve to an absolute path";
+    return false;
+  }
+
+  return true;
+}
+
+static std::string current_sync_timestamp()
+{
+  const auto now     = std::chrono::system_clock::now();
+  const auto seconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
+  const auto millis  = std::chrono::duration_cast<std::chrono::milliseconds>(now - seconds).count();
+  const auto time    = std::chrono::system_clock::to_time_t(now);
+
+  std::tm tm{};
+#if _WIN32
+  gmtime_s(&tm, &time);
+#else
+  gmtime_r(&time, &tm);
+#endif
+
+  std::ostringstream timestamp;
+  timestamp << std::put_time(&tm, "%FT%T") << '.' << std::setw(3) << std::setfill('0') << millis << 'Z';
+  return timestamp.str();
+}
+
+static void write_file_target_data(const std::string& target_identifier, const SyncTargetConfig& target_config,
+                                   SyncConfig::Type type, const std::string& post_data, bool is_first_sync)
+{
+  std::filesystem::path directory;
+  std::string           error;
+  if (!parse_file_target_directory(target_config.url, directory, error)) {
+    sync_log_error(CURL_TYPE_UPLOAD, target_identifier, error);
+    return;
+  }
+
+  nlohmann::json payload = nlohmann::json::parse(post_data, nullptr, false);
+  if (payload.is_discarded()) {
+    payload = post_data;
+  }
+
+  const nlohmann::json envelope{
+      {"type", to_string(type)},
+      {"first_sync", is_first_sync},
+      {"timestamp", current_sync_timestamp()},
+      {"payload", std::move(payload)},
+  };
+
+  std::scoped_lock lk(file_target_mtx);
+
+  std::error_code ec;
+  std::filesystem::create_directories(directory, ec);
+  if (ec) {
+    sync_log_error(CURL_TYPE_UPLOAD, target_identifier,
+                   "Failed to create directory " + directory.string() + ": " + ec.message());
+    return;
+  }
+
+  const auto file_path = directory / (to_string(type) + ".jsonl");
+  std::ofstream out(file_path, std::ios::app);
+  if (!out) {
+    sync_log_error(CURL_TYPE_UPLOAD, target_identifier, "Failed to open " + file_path.string());
+    return;
+  }
+
+  out << envelope.dump() << '\n';
+  if (!out) {
+    sync_log_error(CURL_TYPE_UPLOAD, target_identifier, "Failed to write " + file_path.string());
+    return;
+  }
+
+  sync_log_debug(CURL_TYPE_UPLOAD, target_identifier, "Wrote data to " + file_path.string());
+}
 
 static void target_worker_thread(std::shared_ptr<TargetWorker> worker)
 {
@@ -372,8 +533,14 @@ static void send_data(SyncConfig::Type type, const std::string& post_data, bool 
        | std::views::keys) {
 
     const auto target_identifier = STR_FORMAT("{} ({})", target, to_string(type));
+    const auto& target_config = targets.at(target);
 
     try {
+      if (target_config.is_file_target()) {
+        write_file_target_data(target_identifier, target_config, type, post_data, is_first_sync);
+        continue;
+      }
+
       const auto worker = get_curl_client_sync(target);
 
       // Enqueue the request for this target's worker

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -21,6 +21,7 @@
 #include <rpc.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Web.Http.Headers.h>
+#include <winrt/base.h>
 #else
 #include <uuid/uuid.h>
 #endif
@@ -31,9 +32,11 @@
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cctype>
 #include <ctime>
 #include <filesystem>
 #include <format>
@@ -251,6 +254,26 @@ static int from_hex(const char c)
   return -1;
 }
 
+static bool starts_with_ascii_case_insensitive(std::string_view str, std::string_view prefix)
+{
+  if (str.size() < prefix.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < prefix.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(str[i])) != std::tolower(static_cast<unsigned char>(prefix[i]))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool is_ascii_alpha(const char c)
+{
+  return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+
 static bool decode_file_url_path(std::string_view encoded, std::string& decoded, std::string& error)
 {
   decoded.clear();
@@ -288,26 +311,18 @@ static bool decode_file_url_path(std::string_view encoded, std::string& decoded,
 
 static bool parse_file_target_directory(const std::string& url, std::filesystem::path& directory, std::string& error)
 {
-#if _WIN32
-  (void)url;
-  (void)directory;
-  error = "file:// sync targets are currently supported only on macOS/Linux";
-  return false;
-#else
   static constexpr std::string_view scheme = "file://";
 
-  if (!url.starts_with(scheme)) {
+  if (!starts_with_ascii_case_insensitive(url, scheme)) {
     error = "target URL is not a file URL";
     return false;
   }
 
   std::string_view path_part(url.data() + scheme.size(), url.size() - scheme.size());
-  if (path_part.starts_with("localhost/")) {
+  if (starts_with_ascii_case_insensitive(path_part, "localhost/")) {
     path_part.remove_prefix(std::string_view("localhost").size());
-  }
-
-  if (path_part.empty() || !path_part.starts_with("/")) {
-    error = "file URL must use an absolute local path";
+  } else if (!path_part.empty() && !path_part.starts_with("/")) {
+    error = "file URL must be local; only empty or localhost authorities are supported";
     return false;
   }
 
@@ -321,14 +336,34 @@ static bool parse_file_target_directory(const std::string& url, std::filesystem:
     return false;
   }
 
+#if _WIN32
+  std::replace(decoded.begin(), decoded.end(), '/', '\\');
+
+  if (decoded.size() >= 3 && decoded[0] == '\\' && decoded[2] == ':') {
+    decoded.erase(0, 1);
+  }
+
+  if (decoded.size() < 3 || !is_ascii_alpha(decoded[0]) || decoded[1] != ':'
+      || (decoded[2] != '/' && decoded[2] != '\\')) {
+    error = "file URL must use a local Windows path like file:///C:/path";
+    return false;
+  }
+
+  directory = std::filesystem::path(std::wstring(winrt::to_hstring(decoded)));
+#else
+  if (decoded.empty() || decoded[0] != '/') {
+    error = "file URL must use an absolute local path";
+    return false;
+  }
+
   directory = std::filesystem::path(decoded);
+#endif
   if (!directory.is_absolute()) {
     error = "file URL must resolve to an absolute path";
     return false;
   }
 
   return true;
-#endif
 }
 
 static std::string current_sync_timestamp()

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -37,14 +37,11 @@
 #include <chrono>
 #include <condition_variable>
 #include <cctype>
-#include <ctime>
 #include <filesystem>
 #include <format>
 #include <fstream>
-#include <iomanip>
 #include <mutex>
 #include <queue>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -366,41 +363,17 @@ static bool parse_file_target_directory(const std::string& url, std::filesystem:
   return true;
 }
 
-static std::string current_sync_timestamp()
-{
-  const auto now     = std::chrono::system_clock::now();
-  const auto seconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
-  const auto millis  = std::chrono::duration_cast<std::chrono::milliseconds>(now - seconds).count();
-  const auto time    = std::chrono::system_clock::to_time_t(now);
-
-  std::tm tm{};
-#if _WIN32
-  gmtime_s(&tm, &time);
-#else
-  gmtime_r(&time, &tm);
-#endif
-
-  std::ostringstream timestamp;
-  timestamp << std::put_time(&tm, "%FT%T") << '.' << std::setw(3) << std::setfill('0') << millis << 'Z';
-  return timestamp.str();
-}
-
 static void write_file_target_data(const std::string& target_identifier, const SyncTargetConfig& target_config,
                                    SyncConfig::Type type, const std::string& post_data, bool is_first_sync)
 {
+  (void)is_first_sync;
+
   std::filesystem::path directory;
   std::string           error;
   if (!parse_file_target_directory(target_config.url, directory, error)) {
     sync_log_error(CURL_TYPE_UPLOAD, target_identifier, error);
     return;
   }
-
-  const nlohmann::json envelope{
-      {"type", to_string(type)},
-      {"first_sync", is_first_sync},
-      {"timestamp", current_sync_timestamp()},
-      {"body", post_data},
-  };
 
   std::scoped_lock lk(file_target_mtx);
 
@@ -419,7 +392,7 @@ static void write_file_target_data(const std::string& target_identifier, const S
     return;
   }
 
-  out << envelope.dump() << '\n';
+  out << post_data << '\n';
   if (!out) {
     sync_log_error(CURL_TYPE_UPLOAD, target_identifier, "Failed to write " + file_path.string());
     return;

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -386,7 +386,7 @@ static void write_file_target_data(const std::string& target_identifier, const S
   }
 
   const auto file_path = directory / (to_string(type) + ".jsonl");
-  std::ofstream out(file_path, std::ios::app);
+  std::ofstream out(file_path, std::ios::binary | std::ios::app);
   if (!out) {
     sync_log_error(CURL_TYPE_UPLOAD, target_identifier, "Failed to open " + file_path.string());
     return;


### PR DESCRIPTION
This brings back local sync capture as a sync target transport, not as the old global `sync_file` side path. The old path appended selected raw payloads to one configured file outside the target system; this keeps the existing sync-target model, so per-target data filters still apply and HTTP behavior is unchanged.

## Summary
- allow `file://` sync target URLs without requiring a token
- support local absolute file URLs on macOS/Linux and Windows drive-letter paths such as `file:///C:/Users/you/stfc-sync`
- write one JSONL file per sync type under the target directory
- preserve the existing sync payload body format: each JSONL line is the same JSON request body that would be posted to an HTTP sync target
- document local file target behavior and privacy implications in the example config

## Validation
- built macOS release locally
- configured `[sync.targets.localfile]` with `url = "file:///Users/wycats/Desktop/stfc-sync-smoke"`
- launched the game and confirmed JSONL output was written for `buff`, `inventory`, `job`, `mission`, `resource`, and `ship`
- parsed the first line of each output file as JSON and confirmed the top-level value is the raw sync payload array
- ran careful static review of Windows path handling; I don't have access to a Windows machine to test on
