### PR TITLE
fix: skip loading screen background hooks on macOS

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -355,6 +355,7 @@ auto_confirm_discovery = true
 
 [loading_screen]
 # Enable custom loading screen background
+# This feature currently does not work on macOS.
 # Set to true to use a custom image for the loading screen
 custom_enabled = true
 

--- a/mods/src/patches/parts/loading_screen_bg.cc
+++ b/mods/src/patches/parts/loading_screen_bg.cc
@@ -452,6 +452,11 @@ void LoginSequence_Awake_Hook(auto original, void* _this)
 
 void InstallLoadingScreenBgHooks()
 {
+#if __APPLE__
+  spdlog::info("[LS] Loading screen background hooks skipped on Apple platforms");
+  return;
+#endif
+
   const auto& cfg = Config::Get();
   auto tv_h = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.LoadingScreen", "TransitionViewController");
   auto tm_h = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.LoadingScreen", "TransitionManager");


### PR DESCRIPTION
Return before registering loading screen background detours on Apple builds while leaving the dev implementation in place for other platforms. Document the macOS limitation in the example config.