### PR TITLE
Add raw static EntityGroup capture

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -450,3 +450,17 @@ verify_ssl = true
 
 # The url of the server to send data to
 # url = ""
+
+#  <[========================================]>
+#       Raw static capture
+#  <[========================================]>
+
+# Optional developer tool for capturing raw static/spec EntityGroup protobuf payloads locally.
+# Disabled by default. This does not send data to sync targets and does not parse the payloads.
+# The directory receives content-addressed raw blobs plus a manifest.jsonl index.
+# include_types is a comma-separated numeric EntityGroup type allowlist. Empty means all known static/spec types.
+[sync.raw_static_capture]
+enabled = false
+directory = ""
+max_bytes = 52428800
+include_types = ""

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -23,6 +23,7 @@ namespace DCC = DefaultConfig::Control;
 namespace DCU = DefaultConfig::UI;
 namespace DCBS = DefaultConfig::Buffs;
 namespace DCS = DefaultConfig::Sync;
+namespace DCSR = DefaultConfig::Sync::RawStaticCapture;
 namespace DCSC = DefaultConfig::SystemConfig;
 namespace DCSH = DefaultConfig::Shortcuts;
 namespace DCLS = DefaultConfig::LoadingScreen;
@@ -594,6 +595,47 @@ void Config::Load()
   this->sync_debug              = get_config_or_default(config, parsed, "sync", "debug", DCS::debug, write_config);
   this->sync_logging            = get_config_or_default(config, parsed, "sync", "logging", DCS::logging, write_config);
   this->sync_resolver_cache_ttl = get_config_or_default(config, parsed, "sync", "resolver_cache_ttl", DCS::resolver_cache_ttl, write_config);
+
+  this->raw_static_capture_enabled     = DCSR::enabled;
+  this->raw_static_capture_directory   = DCSR::directory;
+  this->raw_static_capture_max_bytes   = DCSR::max_bytes;
+  auto raw_static_capture_include_types = std::string(DCSR::include_types);
+
+  try {
+    if (const auto sync = config["sync"].as_table()) {
+      if (const auto raw_static_capture = (*sync)["raw_static_capture"].as_table()) {
+        this->raw_static_capture_enabled = (*raw_static_capture)["enabled"].value_or(DCSR::enabled);
+        this->raw_static_capture_directory =
+            (*raw_static_capture)["directory"].value_or(std::string(DCSR::directory));
+        this->raw_static_capture_max_bytes = (*raw_static_capture)["max_bytes"].value_or<int64_t>(DCSR::max_bytes);
+        raw_static_capture_include_types =
+            (*raw_static_capture)["include_types"].value_or(std::string(DCSR::include_types));
+      }
+    }
+  } catch (...) {
+    spdlog::warn("invalid config value sync.raw_static_capture");
+  }
+
+  auto sync_table = parsed["sync"].as_table();
+  sync_table->insert_or_assign("raw_static_capture", toml::table());
+  auto raw_static_capture = (*sync_table)["raw_static_capture"].as_table();
+  raw_static_capture->insert_or_assign("enabled", this->raw_static_capture_enabled);
+  raw_static_capture->insert_or_assign("directory", this->raw_static_capture_directory);
+  raw_static_capture->insert_or_assign("max_bytes", this->raw_static_capture_max_bytes);
+  raw_static_capture->insert_or_assign("include_types", raw_static_capture_include_types);
+
+  this->raw_static_capture_include_types.clear();
+  for (const auto& type : StrSplit(raw_static_capture_include_types, ',')) {
+    if (type.empty()) {
+      continue;
+    }
+
+    try {
+      this->raw_static_capture_include_types.insert(std::stoi(type));
+    } catch (...) {
+      spdlog::warn("invalid sync.raw_static_capture.include_types entry: {}", type);
+    }
+  }
 
   SyncConfig sync_defaults;
   sync_defaults.proxy      = get_config_or_default<std::string>(config, parsed, "sync", "proxy", DCS::proxy , write_log);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <toml++/toml.h>
@@ -186,6 +187,11 @@ public:
   SyncConfig sync_options;
 
   std::map<std::string, SyncTargetConfig> sync_targets;
+
+  bool                         raw_static_capture_enabled;
+  std::string                  raw_static_capture_directory;
+  int64_t                      raw_static_capture_max_bytes;
+  std::unordered_set<int>      raw_static_capture_include_types;
 
   bool installUiScaleHooks;
   bool installZoomHooks;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -189,6 +189,14 @@ namespace Sync
   constexpr bool        logging            = false;
   constexpr bool        verify_ssl         = true;
   constexpr auto        resolver_cache_ttl = 300;
+
+  namespace RawStaticCapture
+  {
+    constexpr bool        enabled       = false;
+    constexpr const char* directory     = "";
+    constexpr auto        max_bytes     = 52428800;
+    constexpr const char* include_types = "";
+  } // namespace RawStaticCapture
 } // namespace Sync
 
 namespace UI

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -281,15 +281,45 @@ static void CaptureRawStaticEntityGroup(EntityGroup::Type type, const char* byte
   }
 
   bool wrote_blob = false;
-  if (!std::filesystem::exists(blob_path, ec)) {
-    std::ofstream blob(blob_path, std::ios::binary | std::ios::trunc);
+  const bool blob_exists = std::filesystem::exists(blob_path, ec);
+  if (ec) {
+    spdlog::error("Failed to check raw static capture blob {}: {}", blob_path.string(), ec.message());
+    return;
+  }
+
+  if (!blob_exists) {
+    const auto temp_blob_path = blob_path.parent_path() / (hash + ".bin.tmp");
+    std::filesystem::remove(temp_blob_path, ec);
+    ec.clear();
+
+    std::ofstream blob(temp_blob_path, std::ios::binary | std::ios::trunc);
     if (!blob) {
-      spdlog::error("Failed to open raw static capture blob {}", blob_path.string());
+      spdlog::error("Failed to open raw static capture blob {}", temp_blob_path.string());
       return;
     }
     blob.write(bytes, static_cast<std::streamsize>(byte_count));
     if (!blob) {
-      spdlog::error("Failed to write raw static capture blob {}", blob_path.string());
+      spdlog::error("Failed to write raw static capture blob {}", temp_blob_path.string());
+      blob.close();
+      std::filesystem::remove(temp_blob_path, ec);
+      ec.clear();
+      return;
+    }
+
+    blob.close();
+    if (!blob) {
+      spdlog::error("Failed to finalize raw static capture blob {}", temp_blob_path.string());
+      std::filesystem::remove(temp_blob_path, ec);
+      ec.clear();
+      return;
+    }
+
+    std::filesystem::rename(temp_blob_path, blob_path, ec);
+    if (ec) {
+      spdlog::error("Failed to move raw static capture blob {} into place at {}: {}", temp_blob_path.string(),
+                    blob_path.string(), ec.message());
+      std::filesystem::remove(temp_blob_path, ec);
+      ec.clear();
       return;
     }
     wrote_blob = true;

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "errormsg.h"
 #include "file.h"
+#include "sha256.h"
 #include "str_utils.h"
 
 #include <il2cpp-api-types.h>
@@ -34,11 +35,14 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <ctime>
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <iomanip>
 #include <mutex>
 #include <queue>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -80,6 +84,234 @@ namespace headers
   static std::string    primeVersion{"1.000.48084"};
   static std::string    poweredBy{"stfc community mod/" VER_FILE_VERSION_STR};
 } // namespace headers
+
+static std::once_flag raw_static_capture_config_warning;
+static std::mutex     raw_static_capture_mtx;
+
+static std::string current_timestamp()
+{
+  const auto now     = std::chrono::system_clock::now();
+  const auto seconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
+  const auto millis  = std::chrono::duration_cast<std::chrono::milliseconds>(now - seconds).count();
+  const auto time    = std::chrono::system_clock::to_time_t(now);
+
+  std::tm tm{};
+#if _WIN32
+  gmtime_s(&tm, &time);
+#else
+  gmtime_r(&time, &tm);
+#endif
+
+  std::ostringstream timestamp;
+  timestamp << std::put_time(&tm, "%FT%T") << '.' << std::setw(3) << std::setfill('0') << millis << 'Z';
+  return timestamp.str();
+}
+
+static const char* EntityGroupTypeName(EntityGroup::Type type)
+{
+  switch (type) {
+    case EntityGroup::Type::HullSpecs: return "HullSpecs";
+    case EntityGroup::Type::ResourceSpecs: return "ResourceSpecs";
+    case EntityGroup::Type::ResourceConversionSpecs: return "ResourceConversionSpecs";
+    case EntityGroup::Type::JobSpeedupResourceSpecs: return "JobSpeedupResourceSpecs";
+    case EntityGroup::Type::StarbaseSpecs: return "StarbaseSpecs";
+    case EntityGroup::Type::OfficerSpecs: return "OfficerSpecs";
+    case EntityGroup::Type::FactionSpecs: return "FactionSpecs";
+    case EntityGroup::Type::FactionBehaviourSpecs: return "FactionBehaviourSpecs";
+    case EntityGroup::Type::UserConsumableSpecs: return "UserConsumableSpecs";
+    case EntityGroup::Type::PlayerXpSpecs: return "PlayerXpSpecs";
+    case EntityGroup::Type::ComponentSpecs: return "ComponentSpecs";
+    case EntityGroup::Type::ObjectiveDefinitions: return "ObjectiveDefinitions";
+    case EntityGroup::Type::AllianceRankSpecs: return "AllianceRankSpecs";
+    case EntityGroup::Type::AllianceLevelSpecs: return "AllianceLevelSpecs";
+    case EntityGroup::Type::AlliancePermissionSpecs: return "AlliancePermissionSpecs";
+    case EntityGroup::Type::OfficerAbilityBuffSpecs: return "OfficerAbilityBuffSpecs";
+    case EntityGroup::Type::OfficerCoreStatSpecs: return "OfficerCoreStatSpecs";
+    case EntityGroup::Type::OfficerIntelRequirementSpecs: return "OfficerIntelRequirementSpecs";
+    case EntityGroup::Type::OfficerSynergyFactorSpecs: return "OfficerSynergyFactorSpecs";
+    case EntityGroup::Type::BlueprintSpecs: return "BlueprintSpecs";
+    case EntityGroup::Type::NavigationConfig: return "NavigationConfig";
+    case EntityGroup::Type::FleetConfig: return "FleetConfig";
+    case EntityGroup::Type::FleetIconConfig: return "FleetIconConfig";
+    case EntityGroup::Type::AllianceConfig: return "AllianceConfig";
+    case EntityGroup::Type::ConsistencyConfig: return "ConsistencyConfig";
+    case EntityGroup::Type::FtueConfig: return "FtueConfig";
+    case EntityGroup::Type::PlacementConfig: return "PlacementConfig";
+    case EntityGroup::Type::DialogConfig: return "DialogConfig";
+    case EntityGroup::Type::FactionConfig: return "FactionConfig";
+    case EntityGroup::Type::ResourceConfig: return "ResourceConfig";
+    case EntityGroup::Type::FtueProgressionConfig: return "FtueProgressionConfig";
+    case EntityGroup::Type::NewPlayerConfig: return "NewPlayerConfig";
+    case EntityGroup::Type::ThreatConfig: return "ThreatConfig";
+    case EntityGroup::Type::StationShieldConfig: return "StationShieldConfig";
+    case EntityGroup::Type::PlanetSlotsConfig: return "PlanetSlotsConfig";
+    case EntityGroup::Type::OfficerConfig: return "OfficerConfig";
+    case EntityGroup::Type::BattleConfig: return "BattleConfig";
+    case EntityGroup::Type::StarbaseConfig: return "StarbaseConfig";
+    case EntityGroup::Type::ShipXpConfig: return "ShipXpConfig";
+    case EntityGroup::Type::OptimisedGalaxy: return "OptimisedGalaxy";
+    case EntityGroup::Type::Json: return "Json";
+    case EntityGroup::Type::OfficerCoreStatThresholdsSpecs: return "OfficerCoreStatThresholdsSpecs";
+    case EntityGroup::Type::OfficerPromotionSpecs: return "OfficerPromotionSpecs";
+    case EntityGroup::Type::ClientShipStatLookupSpecs: return "ClientShipStatLookupSpecs";
+    case EntityGroup::Type::BaseShipTierSpecs: return "BaseShipTierSpecs";
+    case EntityGroup::Type::ShipTierSpecs: return "ShipTierSpecs";
+    case EntityGroup::Type::ShipBonusBuffSpecs: return "ShipBonusBuffSpecs";
+    case EntityGroup::Type::MitigationCapsSpecs: return "MitigationCapsSpecs";
+    case EntityGroup::Type::GlobalDamageReductionConfig: return "GlobalDamageReductionConfig";
+    case EntityGroup::Type::BuffTargetSpecs: return "BuffTargetSpecs";
+    case EntityGroup::Type::BuffTriggerSpecs: return "BuffTriggerSpecs";
+    case EntityGroup::Type::MissionSpecs: return "MissionSpecs";
+    case EntityGroup::Type::ActionSpecs: return "ActionSpecs";
+    case EntityGroup::Type::ShipLevelUpBonusBuffsSpecs: return "ShipLevelUpBonusBuffsSpecs";
+    case EntityGroup::Type::ResearchSpecs: return "ResearchSpecs";
+    case EntityGroup::Type::PvpBanding: return "PvpBanding";
+    case EntityGroup::Type::ArmadaAttackSpecs: return "ArmadaAttackSpecs";
+    case EntityGroup::Type::ArmadaConfig: return "ArmadaConfig";
+    case EntityGroup::Type::ServerTransferConfig: return "ServerTransferConfig";
+    case EntityGroup::Type::MiningSetupConfig: return "MiningSetupConfig";
+    case EntityGroup::Type::ScrapyardSpecs: return "ScrapyardSpecs";
+    case EntityGroup::Type::CosmeticSpecs: return "CosmeticSpecs";
+    case EntityGroup::Type::ArmadaPveSpecs: return "ArmadaPveSpecs";
+    case EntityGroup::Type::PrestigeData: return "PrestigeData";
+    case EntityGroup::Type::TerritoryStaticData: return "TerritoryStaticData";
+    case EntityGroup::Type::WorkerSpecs: return "WorkerSpecs";
+    case EntityGroup::Type::AwayAssignmentsStatic: return "AwayAssignmentsStatic";
+    case EntityGroup::Type::ConsumableSpecs: return "ConsumableSpecs";
+    case EntityGroup::Type::SlotSpecs: return "SlotSpecs";
+    case EntityGroup::Type::TraitsSpecs: return "TraitsSpecs";
+    case EntityGroup::Type::OfficerTraitsSpecs: return "OfficerTraitsSpecs";
+    case EntityGroup::Type::LoyaltySpecs: return "LoyaltySpecs";
+    case EntityGroup::Type::PeaceShieldRulesSpecs: return "PeaceShieldRulesSpecs";
+    case EntityGroup::Type::MarauderInfo: return "MarauderInfo";
+    case EntityGroup::Type::AllianceStarbaseConfig: return "AllianceStarbaseConfig";
+    case EntityGroup::Type::Gameworld: return "Gameworld";
+    case EntityGroup::Type::ActivatedAbilitySpecs: return "ActivatedAbilitySpecs";
+    case EntityGroup::Type::AchievementsConfig: return "AchievementsConfig";
+    case EntityGroup::Type::ArmadaPvpSpecs: return "ArmadaPvpSpecs";
+    case EntityGroup::Type::OfficerProgressRewardSpecs: return "OfficerProgressRewardSpecs";
+    case EntityGroup::Type::CommanderSkillSpecs: return "CommanderSkillSpecs";
+    case EntityGroup::Type::CommanderIntelRequirementSpecs: return "CommanderIntelRequirementSpecs";
+    case EntityGroup::Type::HailingFreqConfig: return "HailingFreqConfig";
+    case EntityGroup::Type::OfficerLevelRewardsSpecs: return "OfficerLevelRewardsSpecs";
+    case EntityGroup::Type::ResourceGroupsSpec: return "ResourceGroupsSpec";
+    case EntityGroup::Type::ChallengeLadderSpecs: return "ChallengeLadderSpecs";
+    case EntityGroup::Type::BundleRewardsSpecs: return "BundleRewardsSpecs";
+    case EntityGroup::Type::ForbiddenTechSpecs: return "ForbiddenTechSpecs";
+    case EntityGroup::Type::ForbiddenTechBuffs: return "ForbiddenTechBuffs";
+    case EntityGroup::Type::ForbiddenTechRemovalCosts: return "ForbiddenTechRemovalCosts";
+    case EntityGroup::Type::ForbiddenTechConfig: return "ForbiddenTechConfig";
+    case EntityGroup::Type::ChallengeConfig: return "ChallengeConfig";
+    case EntityGroup::Type::ForbiddenTechUpgradeCosts: return "ForbiddenTechUpgradeCosts";
+    case EntityGroup::Type::HazardSpecs: return "HazardSpecs";
+    case EntityGroup::Type::ActivatedShipAbilitiesConfigs: return "ActivatedShipAbilitiesConfigs";
+    case EntityGroup::Type::WaveDefenseStaticData: return "WaveDefenseStaticData";
+    case EntityGroup::Type::AllianceLoyaltyStaticData: return "AllianceLoyaltyStaticData";
+    case EntityGroup::Type::GameActivitySpecs: return "GameActivitySpecs";
+    case EntityGroup::Type::GameActivityParticipantSpecs: return "GameActivityParticipantSpecs";
+    case EntityGroup::Type::GameActivityDetailedSpec: return "GameActivityDetailedSpec";
+    case EntityGroup::Type::GameActivityScheduleSpec: return "GameActivityScheduleSpec";
+    case EntityGroup::Type::PartySpecs: return "PartySpecs";
+    case EntityGroup::Type::ResourceAutoConvertSpecs: return "ResourceAutoConvertSpecs";
+    case EntityGroup::Type::AllianceTagSpecs: return "AllianceTagSpecs";
+    case EntityGroup::Type::GameActivityRewardsSpec: return "GameActivityRewardsSpec";
+    case EntityGroup::Type::GameActivityIndex: return "GameActivityIndex";
+    default: return nullptr;
+  }
+}
+
+static bool IsRawStaticCaptureType(EntityGroup::Type type)
+{
+  return EntityGroupTypeName(type) != nullptr;
+}
+
+static bool ShouldRawCaptureStaticGroup(EntityGroup::Type type, size_t byte_count)
+{
+  const auto& cfg = Config::Get();
+  if (!cfg.raw_static_capture_enabled) {
+    return false;
+  }
+
+  if (cfg.raw_static_capture_directory.empty()) {
+    std::call_once(raw_static_capture_config_warning, [] {
+      spdlog::error("sync.raw_static_capture.enabled is true, but sync.raw_static_capture.directory is empty");
+    });
+    return false;
+  }
+
+  if (!IsRawStaticCaptureType(type)) {
+    return false;
+  }
+
+  if (!cfg.raw_static_capture_include_types.empty()
+      && cfg.raw_static_capture_include_types.find(static_cast<int>(type)) == cfg.raw_static_capture_include_types.end()) {
+    return false;
+  }
+
+  if (cfg.raw_static_capture_max_bytes > 0 && byte_count > static_cast<size_t>(cfg.raw_static_capture_max_bytes)) {
+    spdlog::warn("Skipping raw static capture for type {} ({}): {} bytes exceeds max_bytes {}", static_cast<int>(type),
+                 EntityGroupTypeName(type), byte_count, cfg.raw_static_capture_max_bytes);
+    return false;
+  }
+
+  return true;
+}
+
+static void CaptureRawStaticEntityGroup(EntityGroup::Type type, const char* bytes, size_t byte_count)
+{
+  if (!ShouldRawCaptureStaticGroup(type, byte_count)) {
+    return;
+  }
+
+  const std::string_view payload(bytes, byte_count);
+  const auto hash = sha256::hex(payload);
+  const auto type_name = EntityGroupTypeName(type);
+  const auto root = std::filesystem::path(Config::Get().raw_static_capture_directory);
+  const auto blob_dir = root / "blobs" / "sha256" / hash.substr(0, 2);
+  const auto blob_path = blob_dir / (hash + ".bin");
+  const auto manifest_path = root / "manifest.jsonl";
+
+  std::scoped_lock lk(raw_static_capture_mtx);
+
+  std::error_code ec;
+  std::filesystem::create_directories(blob_dir, ec);
+  if (ec) {
+    spdlog::error("Failed to create raw static capture directory {}: {}", blob_dir.string(), ec.message());
+    return;
+  }
+
+  bool wrote_blob = false;
+  if (!std::filesystem::exists(blob_path, ec)) {
+    std::ofstream blob(blob_path, std::ios::binary | std::ios::trunc);
+    if (!blob) {
+      spdlog::error("Failed to open raw static capture blob {}", blob_path.string());
+      return;
+    }
+    blob.write(bytes, static_cast<std::streamsize>(byte_count));
+    if (!blob) {
+      spdlog::error("Failed to write raw static capture blob {}", blob_path.string());
+      return;
+    }
+    wrote_blob = true;
+  }
+
+  std::ofstream manifest(manifest_path, std::ios::binary | std::ios::app);
+  if (!manifest) {
+    spdlog::error("Failed to open raw static capture manifest {}", manifest_path.string());
+    return;
+  }
+
+  const auto manifest_entry = nlohmann::json{
+      {"timestamp", current_timestamp()},
+      {"type", static_cast<int>(type)},
+      {"type_name", type_name},
+      {"byte_count", byte_count},
+      {"sha256", hash},
+      {"file", (std::filesystem::path("blobs") / "sha256" / hash.substr(0, 2) / (hash + ".bin")).generic_string()},
+      {"status", wrote_blob ? "written" : "already_exists"},
+  };
+  manifest << manifest_entry.dump() << '\n';
+}
 
 [[nodiscard]] static std::string newUUID()
 {
@@ -1915,6 +2147,8 @@ void HandleEntityGroup(EntityGroup* entity_group)
 
   const auto byteCount = static_cast<size_t>(entity_group->Group->Length);
   const auto *bytesPtr = reinterpret_cast<const char*>(entity_group->Group->bytes->m_Items);
+
+  http::CaptureRawStaticEntityGroup(entity_group->Type_, bytesPtr, byteCount);
 
   // Helper to run processing asynchronously with exception handling
   auto submit_async = [bytesPtr, byteCount]<typename T>(T&& func) {

--- a/mods/src/sha256.cc
+++ b/mods/src/sha256.cc
@@ -1,0 +1,147 @@
+#include "sha256.h"
+
+#include <array>
+#include <bit>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+namespace sha256
+{
+namespace
+{
+constexpr std::array<uint32_t, 64> k{
+    0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U, 0x3956c25bU, 0x59f111f1U, 0x923f82a4U,
+    0xab1c5ed5U, 0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U, 0x72be5d74U, 0x80deb1feU,
+    0x9bdc06a7U, 0xc19bf174U, 0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU, 0x2de92c6fU,
+    0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU, 0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U,
+    0xc6e00bf3U, 0xd5a79147U, 0x06ca6351U, 0x14292967U, 0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU,
+    0x53380d13U, 0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U, 0xa2bfe8a1U, 0xa81a664bU,
+    0xc24b8b70U, 0xc76c51a3U, 0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U, 0x19a4c116U,
+    0x1e376c08U, 0x2748774cU, 0x34b0bcb5U, 0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
+    0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U, 0x90befffaU, 0xa4506cebU, 0xbef9a3f7U,
+    0xc67178f2U};
+
+constexpr uint32_t choose(uint32_t x, uint32_t y, uint32_t z)
+{
+  return (x & y) ^ (~x & z);
+}
+
+constexpr uint32_t majority(uint32_t x, uint32_t y, uint32_t z)
+{
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+constexpr uint32_t big_sigma0(uint32_t x)
+{
+  return std::rotr(x, 2) ^ std::rotr(x, 13) ^ std::rotr(x, 22);
+}
+
+constexpr uint32_t big_sigma1(uint32_t x)
+{
+  return std::rotr(x, 6) ^ std::rotr(x, 11) ^ std::rotr(x, 25);
+}
+
+constexpr uint32_t small_sigma0(uint32_t x)
+{
+  return std::rotr(x, 7) ^ std::rotr(x, 18) ^ (x >> 3);
+}
+
+constexpr uint32_t small_sigma1(uint32_t x)
+{
+  return std::rotr(x, 17) ^ std::rotr(x, 19) ^ (x >> 10);
+}
+
+uint32_t read_be32(const uint8_t* p)
+{
+  return (static_cast<uint32_t>(p[0]) << 24) | (static_cast<uint32_t>(p[1]) << 16) |
+         (static_cast<uint32_t>(p[2]) << 8) | static_cast<uint32_t>(p[3]);
+}
+
+void write_be32(uint8_t* p, uint32_t value)
+{
+  p[0] = static_cast<uint8_t>(value >> 24);
+  p[1] = static_cast<uint8_t>(value >> 16);
+  p[2] = static_cast<uint8_t>(value >> 8);
+  p[3] = static_cast<uint8_t>(value);
+}
+} // namespace
+
+digest_t digest(std::string_view data)
+{
+  std::array<uint32_t, 8> h{0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU,
+                            0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U};
+
+  const uint64_t bit_len = static_cast<uint64_t>(data.size()) * 8U;
+  const size_t padded_size = ((data.size() + 9U + 63U) / 64U) * 64U;
+  std::vector<uint8_t> padded(padded_size, 0);
+  std::memcpy(padded.data(), data.data(), data.size());
+  padded[data.size()] = 0x80U;
+  for (int i = 0; i < 8; ++i) {
+    padded[padded_size - 1 - i] = static_cast<uint8_t>(bit_len >> (i * 8));
+  }
+
+  for (size_t offset = 0; offset < padded.size(); offset += 64) {
+    std::array<uint32_t, 64> w{};
+    for (int i = 0; i < 16; ++i) {
+      w[i] = read_be32(padded.data() + offset + i * 4);
+    }
+    for (int i = 16; i < 64; ++i) {
+      w[i] = small_sigma1(w[i - 2]) + w[i - 7] + small_sigma0(w[i - 15]) + w[i - 16];
+    }
+
+    uint32_t a = h[0];
+    uint32_t b = h[1];
+    uint32_t c = h[2];
+    uint32_t d = h[3];
+    uint32_t e = h[4];
+    uint32_t f = h[5];
+    uint32_t g = h[6];
+    uint32_t hh = h[7];
+
+    for (int i = 0; i < 64; ++i) {
+      const uint32_t t1 = hh + big_sigma1(e) + choose(e, f, g) + k[i] + w[i];
+      const uint32_t t2 = big_sigma0(a) + majority(a, b, c);
+      hh = g;
+      g = f;
+      f = e;
+      e = d + t1;
+      d = c;
+      c = b;
+      b = a;
+      a = t1 + t2;
+    }
+
+    h[0] += a;
+    h[1] += b;
+    h[2] += c;
+    h[3] += d;
+    h[4] += e;
+    h[5] += f;
+    h[6] += g;
+    h[7] += hh;
+  }
+
+  digest_t out{};
+  for (int i = 0; i < 8; ++i) {
+    write_be32(out.data() + i * 4, h[i]);
+  }
+  return out;
+}
+
+std::string hex(const digest_t& digest)
+{
+  std::ostringstream out;
+  out << std::hex << std::setfill('0');
+  for (const auto byte : digest) {
+    out << std::setw(2) << static_cast<int>(byte);
+  }
+  return out.str();
+}
+
+std::string hex(std::string_view data)
+{
+  return hex(digest(data));
+}
+} // namespace sha256

--- a/mods/src/sha256.cc
+++ b/mods/src/sha256.cc
@@ -2,10 +2,9 @@
 
 #include <array>
 #include <bit>
-#include <cstring>
+#include <cstddef>
 #include <iomanip>
 #include <sstream>
-#include <vector>
 
 namespace sha256
 {
@@ -66,6 +65,55 @@ void write_be32(uint8_t* p, uint32_t value)
   p[2] = static_cast<uint8_t>(value >> 8);
   p[3] = static_cast<uint8_t>(value);
 }
+
+void write_be64(uint8_t* p, uint64_t value)
+{
+  for (int i = 0; i < 8; ++i) {
+    p[7 - i] = static_cast<uint8_t>(value >> (i * 8));
+  }
+}
+
+void transform(std::array<uint32_t, 8>& h, const uint8_t* block)
+{
+  std::array<uint32_t, 64> w{};
+  for (int i = 0; i < 16; ++i) {
+    w[i] = read_be32(block + i * 4);
+  }
+  for (int i = 16; i < 64; ++i) {
+    w[i] = small_sigma1(w[i - 2]) + w[i - 7] + small_sigma0(w[i - 15]) + w[i - 16];
+  }
+
+  uint32_t a = h[0];
+  uint32_t b = h[1];
+  uint32_t c = h[2];
+  uint32_t d = h[3];
+  uint32_t e = h[4];
+  uint32_t f = h[5];
+  uint32_t g = h[6];
+  uint32_t hh = h[7];
+
+  for (int i = 0; i < 64; ++i) {
+    const uint32_t t1 = hh + big_sigma1(e) + choose(e, f, g) + k[i] + w[i];
+    const uint32_t t2 = big_sigma0(a) + majority(a, b, c);
+    hh = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+
+  h[0] += a;
+  h[1] += b;
+  h[2] += c;
+  h[3] += d;
+  h[4] += e;
+  h[5] += f;
+  h[6] += g;
+  h[7] += hh;
+}
 } // namespace
 
 digest_t digest(std::string_view data)
@@ -74,54 +122,27 @@ digest_t digest(std::string_view data)
                             0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U};
 
   const uint64_t bit_len = static_cast<uint64_t>(data.size()) * 8U;
-  const size_t padded_size = ((data.size() + 9U + 63U) / 64U) * 64U;
-  std::vector<uint8_t> padded(padded_size, 0);
-  std::memcpy(padded.data(), data.data(), data.size());
-  padded[data.size()] = 0x80U;
-  for (int i = 0; i < 8; ++i) {
-    padded[padded_size - 1 - i] = static_cast<uint8_t>(bit_len >> (i * 8));
+  const auto* bytes = reinterpret_cast<const uint8_t*>(data.data());
+  size_t offset = 0;
+
+  for (; offset + 64 <= data.size(); offset += 64) {
+    transform(h, bytes + offset);
   }
 
-  for (size_t offset = 0; offset < padded.size(); offset += 64) {
-    std::array<uint32_t, 64> w{};
-    for (int i = 0; i < 16; ++i) {
-      w[i] = read_be32(padded.data() + offset + i * 4);
-    }
-    for (int i = 16; i < 64; ++i) {
-      w[i] = small_sigma1(w[i - 2]) + w[i - 7] + small_sigma0(w[i - 15]) + w[i - 16];
-    }
-
-    uint32_t a = h[0];
-    uint32_t b = h[1];
-    uint32_t c = h[2];
-    uint32_t d = h[3];
-    uint32_t e = h[4];
-    uint32_t f = h[5];
-    uint32_t g = h[6];
-    uint32_t hh = h[7];
-
-    for (int i = 0; i < 64; ++i) {
-      const uint32_t t1 = hh + big_sigma1(e) + choose(e, f, g) + k[i] + w[i];
-      const uint32_t t2 = big_sigma0(a) + majority(a, b, c);
-      hh = g;
-      g = f;
-      f = e;
-      e = d + t1;
-      d = c;
-      c = b;
-      b = a;
-      a = t1 + t2;
-    }
-
-    h[0] += a;
-    h[1] += b;
-    h[2] += c;
-    h[3] += d;
-    h[4] += e;
-    h[5] += f;
-    h[6] += g;
-    h[7] += hh;
+  std::array<uint8_t, 128> tail{};
+  size_t tail_size = data.size() - offset;
+  for (size_t i = 0; i < tail_size; ++i) {
+    tail[i] = bytes[offset + i];
   }
+  tail[tail_size++] = 0x80U;
+
+  if (tail_size > 56) {
+    transform(h, tail.data());
+    tail.fill(0);
+  }
+
+  write_be64(tail.data() + 56, bit_len);
+  transform(h, tail.data());
 
   digest_t out{};
   for (int i = 0; i < 8; ++i) {

--- a/mods/src/sha256.h
+++ b/mods/src/sha256.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace sha256
+{
+using digest_t = std::array<uint8_t, 32>;
+
+[[nodiscard]] digest_t digest(std::string_view data);
+[[nodiscard]] std::string hex(const digest_t& digest);
+[[nodiscard]] std::string hex(std::string_view data);
+} // namespace sha256


### PR DESCRIPTION
## Summary

Adds an opt-in local developer capture path for raw static/spec `EntityGroup` payloads.

When enabled, the mod writes raw protobuf bytes to a local content-addressed blob store and appends JSONL manifest entries with:

- timestamp
- `EntityGroup` numeric type
- type name
- byte count
- SHA-256
- relative blob path
- whether the blob was newly written or already present

This is intended as infrastructure for later static catalog extraction work. It does not parse the payloads and does not send them to sync targets.

## Configuration

Adds `[sync.raw_static_capture]`:

- `enabled = false`
- `directory = ""`
- `max_bytes = 52428800`
- `include_types = ""`

`include_types` is an optional comma-separated numeric `EntityGroup` allowlist. Empty captures all known static/spec/config types.

## Scope

- Local-only raw capture
- Static/spec/config allowlist only
- No HTTP upload
- No dynamic player/account data capture
- No typed decoding yet
- No localization/assets extraction yet

## Validation

- `git diff --check`
- `./scripts/mac-build-test-debug.sh -m release build`
- macOS runtime smoke with capture enabled wrote `manifest.jsonl` plus content-addressed blobs under `/Users/wycats/Desktop/stfc-static-capture-smoke`
  - 183 manifest entries
  - 92 unique blob files
  - sample captured types included `BlueprintSpecs`, `StarbaseSpecs`, `ResourceSpecs`, `HazardSpecs`, and `OfficerLevelRewardsSpecs`
  - verified a captured blob path hash with `shasum -a 256`
