### PR TITLE
fix: make mac launcher builds more robust. 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,12 @@ jobs:
       - name: Build (x86)
         run: xmake -y
 
+      - name: Rebuild launcher assets
+        run: |
+          xmake f -p macosx -a "arm64" -m release -y --target_minver=13.5
+          xmake -r -y macOSLauncher
+          test -f build/macosx/arm64/release/macOSLauncher.app/Contents/Resources/Assets.car
+
       - name: Create App Bundle
         run: |
           lipo -create build/macosx/arm64/release/macOSLauncher build/macosx/x86_64/release/macOSLauncher -output build/macosx/arm64/release/macOSLauncher.app/Contents/MacOS/macOSLauncher
@@ -78,6 +84,7 @@ jobs:
           cp assets/launcher.icns build/macosx/arm64/release/macOSLauncher.app/Contents/Resources/
           cp macos-launcher/src/Info.plist build/macosx/arm64/release/macOSLauncher.app/Contents/
           mv build/macosx/arm64/release/macOSLauncher.app build/macosx/arm64/release/STFC\ Community\ Mod.app
+          test -f build/macosx/arm64/release/STFC\ Community\ Mod.app/Contents/Resources/Assets.car
 
       - name: Sign App Bundle
         run: codesign --force --verify --verbose --deep --sign "-" build/macosx/arm64/release/STFC\ Community\ Mod.app

--- a/macos-launcher/src/ActionView.swift
+++ b/macos-launcher/src/ActionView.swift
@@ -70,67 +70,63 @@ struct ActionView: View, XSollaUpdaterDelegate {
     GeometryReader { geo in
       Grid {
         GridRow {
+          Button {
+            withAnimation {
+              openSettings()
+            }
+          } label: {
+            commonButton(text: "Open Settings")
+              .foregroundColor(.lcarViolet)
+          }.buttonStyle(PlainButtonStyle())
+
           if gameInstalled {
-            Button {
-              withAnimation {
-                openSettings()
-              }
-            } label: {
-              commonButton(text: "Open Settings")
-                .foregroundColor(.lcarViolet)
-            }.buttonStyle(PlainButtonStyle())
-            Button {
-              withAnimation {
-                if gameUpdateAvailable && !updating {
-                  Task {
-                    do {
-                      updating = true
-                      updateAction = "Starting"
-                      updateSubAction = "Planning"
-                      try await gameUpdater.updateGame(delegate: self)
-                    } catch {
-                      logger.error("Error updating game: \(error.localizedDescription)")
+            Group {
+              Button {
+                withAnimation {
+                  if gameUpdateAvailable && !updating {
+                    Task {
+                      do {
+                        updating = true
+                        updateAction = "Starting"
+                        updateSubAction = "Planning"
+                        try await gameUpdater.updateGame(delegate: self)
+                      } catch {
+                        logger.error("Error updating game: \(error.localizedDescription)")
+                      }
+                      updating = false
+                      gameVersion = gameUpdater.getInstalledGameVersion()
+                      gameUpdateAvailable = await gameUpdater.checkForGameUpdate()
                     }
-                    updating = false
-                    gameVersion = gameUpdater.getInstalledGameVersion()
-                    gameUpdateAvailable = await gameUpdater.checkForGameUpdate()
                   }
                 }
-              }
-            } label: {
-              if gameUpdateAvailable {
-                commonButton(text: "Update Game!")
-                  .foregroundColor(.lcarTan)
-              } else {
-                commonButton()
-                  .foregroundColor(.lcarTan)
-              }
-            }.buttonStyle(PlainButtonStyle())
-            Button {
-              withAnimation {
-                launchGame()
-              }
-            } label: {
-              commonButton(text: "Engage!")
-                .foregroundColor(.lcarOrange)
-            }.buttonStyle(PlainButtonStyle())
+              } label: {
+                if gameUpdateAvailable {
+                  commonButton(text: "Update Game!")
+                    .foregroundColor(.lcarTan)
+                } else {
+                  commonButton()
+                    .foregroundColor(.lcarTan)
+                }
+              }.buttonStyle(PlainButtonStyle())
+              Button {
+                withAnimation {
+                  launchGame()
+                }
+              } label: {
+                commonButton(text: "Engage!")
+                  .foregroundColor(.lcarOrange)
+              }.buttonStyle(PlainButtonStyle())
+            }
+            .opacity(updating || gameRunning ? 0.5 : 1.0)
+            .allowsHitTesting(!updating && !gameRunning)
           } else {
             Text("Game not installed")
               .font(.custom("HelveticaNeue-CondensedBold", size: 40))
               .foregroundColor(.lcarTan)
               .offset(x: -45)
-            //Button {
-            //  withAnimation {
-            //  }
-            //} label: {
-            //  commonButton(text: "Install Game!")
-            //    .foregroundColor(.lcarTan)
-            //}.buttonStyle(PlainButtonStyle())
           }
 
         }
-        .opacity(updating || gameRunning ? 0.5 : 1.0)
-        .allowsHitTesting(!updating && !gameRunning)
       }
       .frame(width: geo.size.width, height: 150)
       .offset(x: 85, y: 20)

--- a/scripts/create-mac-dmg.sh
+++ b/scripts/create-mac-dmg.sh
@@ -14,6 +14,12 @@ xmake
 xmake f -y -p macosx -a "x86_64" -m $CONFIG --target_minver=15.4
 xmake
 
+# Rebuild the package app bundle after switching architectures so xcode.xcassets
+# regenerates Assets.car even when xmake clean leaves stale asset dependencies.
+xmake f -y -p macosx -a "$ARCH" -m "$CONFIG" --target_minver=15.4
+xmake -r -y macOSLauncher
+test -f "build/macosx/$ARCH/$CONFIG/macOSLauncher.app/Contents/Resources/Assets.car"
+
 rm build/macosx/$ARCH/$CONFIG/libmods.a || true
 
 lipo -create build/macosx/$ARCH/$CONFIG/macOSLauncher build/macosx/x86_64/$CONFIG/macOSLauncher -output build/macosx/$ARCH/$CONFIG/macOSLauncher.app/Contents/MacOS/macOSLauncher
@@ -27,6 +33,7 @@ rm -rf build/macosx/$ARCH/$CONFIG/STFC\ Community\ Mod.app || true
 rm stfc-community-mod-installer.dmg || true
 
 mv build/macosx/$ARCH/$CONFIG/macOSLauncher.app build/macosx/$ARCH/$CONFIG/STFC\ Community\ Mod.app
+test -f "build/macosx/$ARCH/$CONFIG/STFC Community Mod.app/Contents/Resources/Assets.car"
 
 codesign --force --verify --verbose --deep --sign "-" build/macosx/$ARCH/$CONFIG/STFC\ Community\ Mod.app
 


### PR DESCRIPTION
xmake does not rebuild the asset bundle if not needed, but this also skips the step that copies the asset bundle to where the dmg builder is looking for it.

also update the launcher code to make the settings button always accessible.