### PR TITLE
Fix fleet key double-tap detection

### DIFF
--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -73,6 +73,7 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
   // This function is called every frame to update the screen manager.
   // Create a global clock to detect time elapsed
   static std::chrono::time_point<std::chrono::steady_clock> select_clock = std::chrono::steady_clock::now();
+  static int32_t last_ship_select_request = -1;
 
   Key::ResetCache();
 
@@ -154,7 +155,8 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
         std::chrono::milliseconds                          select_diff =
             std::chrono::duration_cast<std::chrono::milliseconds>(select_now - select_clock);
         spdlog::debug("select_diff was {}ms", select_diff.count());
-        if (can_locate && fleet_bar->IsIndexSelected(ship_select_request)
+        if (can_locate && ship_select_request == last_ship_select_request
+            && fleet_bar->IsIndexSelected(ship_select_request)
             && select_diff < std::chrono::milliseconds((int)Config::Get().select_timer)) {
           auto fleet = fleet_bar->_fleetPanelController->fleet;
           if (NavigationSectionManager::Instance() && NavigationSectionManager::Instance()->SNavigationManager) {
@@ -165,6 +167,7 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
           fleet_bar->RequestSelect(ship_select_request);
         }
 
+        last_ship_select_request = ship_select_request;
         select_clock = select_now;
         return;
       }


### PR DESCRIPTION
## Summary

Fixes cross-key double-tap detection for fleet selection hotkeys.

The double-tap timer was shared across all fleet number keys, so pressing two different fleet keys quickly could treat the second key as a double-tap. This tracks the last fleet key used for selection and only enters the double-tap locate path when the current key matches the previous key.

Fixes #134

## Validation

- `xmake f -m releasedbg -y`
- `xmake build stfc-community-mod`