### PR TITLE
fix(mac): BuffService.ParseBinaryObject signature changed,

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ void SomeFunction_Hook(auto original, SomeClass* _this, ...) {
 }
 ```
 macOS does not tolerate repeated hooks of the same function. If multiple features need to intercept the same game method, consolidate the behavior behind one detour or add platform guards instead of installing overlapping hooks.
+Do not over-focus on hidden IL2CPP `MethodInfo*` parameters during drift repair; match the game-visible signature from `dump.cs` unless there is concrete runtime evidence that the hidden parameter is the issue.
 
 **IL2CPP class resolution** — Game classes are resolved at runtime using helpers:
 ```cpp

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -2171,23 +2171,23 @@ void InstallSyncPatches()
     }
   }
 
+#if __APPLE__
+  // 1.000.49105: BuffService.ParseBinaryObject is a 0x18-byte body immediately before HandleResponseData.
+  // Spud's ARM64 absolute jump is larger than that, so detouring it overwrites the next function entry.
+  spdlog::info("Skipping BuffService hook lookup on macOS");
+#else
   if (auto buff_service =
           il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Services", "BuffService");
       !buff_service.isValidHelper()) {
     ErrorMsg::MissingHelper("Services", "BuffService");
   } else {
-#if __APPLE__
-    // 1.000.49105: BuffService.ParseBinaryObject is a 0x18-byte body immediately before HandleResponseData.
-    // Spud's ARM64 absolute jump is larger than that, so detouring it overwrites the next function entry.
-    spdlog::info("Skipping BuffService.ParseBinaryObject hook on macOS");
-#else
     if (auto *const ptr = buff_service.GetMethod("ParseBinaryObject"); ptr == nullptr) {
       ErrorMsg::MissingMethod("BuffService", "ParseBinaryObject");
     } else {
       SPUD_STATIC_DETOUR(ptr, DataContainer_ParseBinaryObject);
     }
-#endif
   }
+#endif
 
   if (auto inventory_data_container = il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime",
                                                               "Digit.PrimeServer.Services", "InventoryDataContainer");

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -2018,11 +2018,19 @@ void HandleEntityGroup(EntityGroup* entity_group)
   }
 }
 
+#if __APPLE__
+void DataContainer_ParseBinaryObject(auto original, void* _this, EntityGroup* group)
+{
+  HandleEntityGroup(group);
+  return original(_this, group);
+}
+#else
 void DataContainer_ParseBinaryObject(auto original, void* _this, EntityGroup* group, bool isPlayerData)
 {
   HandleEntityGroup(group);
   return original(_this, group, isPlayerData);
 }
+#endif
 
 void DataContainer_ParseEntitySlotsData(auto original, void* _this, EntityGroup* group)
 {
@@ -2168,11 +2176,17 @@ void InstallSyncPatches()
       !buff_service.isValidHelper()) {
     ErrorMsg::MissingHelper("Services", "BuffService");
   } else {
+#if __APPLE__
+    // 1.000.49105: BuffService.ParseBinaryObject is a 0x18-byte body immediately before HandleResponseData.
+    // Spud's ARM64 absolute jump is larger than that, so detouring it overwrites the next function entry.
+    spdlog::info("Skipping BuffService.ParseBinaryObject hook on macOS");
+#else
     if (auto *const ptr = buff_service.GetMethod("ParseBinaryObject"); ptr == nullptr) {
       ErrorMsg::MissingMethod("BuffService", "ParseBinaryObject");
     } else {
       SPUD_STATIC_DETOUR(ptr, DataContainer_ParseBinaryObject);
     }
+#endif
   }
 
   if (auto inventory_data_container = il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime",


### PR DESCRIPTION
Hook no longer needed because it just pulls out a pointer and calls another function we hook.