### PR TITLE
Fix loading texture reset and disable loading screen transition

### DIFF
--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -44,7 +44,7 @@ namespace Graphics
   constexpr auto        ui_scale_viewer             = 1.2;
   constexpr bool        use_presets_as_default      = true;
   constexpr auto        zoom                        = 5000;
-  constexpr bool        loader_transition           = true; // replace TVC/SlideShow backgrounds
+  constexpr bool        loader_transition           = false; // replace TVC/SlideShow backgrounds
   constexpr bool        loader_enabled              = true; // replace LoginSequence background
   constexpr const char* loader_image                = "";   // Empty = use embedded fallback
 } // namespace Graphics

--- a/mods/src/patches/parts/loading_screen_bg.cc
+++ b/mods/src/patches/parts/loading_screen_bg.cc
@@ -319,10 +319,11 @@ void TransitionViewController_Awake_Hook(auto original, void* _this)
   try {
     if (!Config::Get().loader_transition)
       return;
-    g_spriteApplied   = false;
-    g_bgImageComp     = nullptr;
-    g_ourSprite       = nullptr;
-    g_bgRectTransform = nullptr;
+    g_spriteApplied        = false;
+    g_bgImageComp          = nullptr;
+    g_ourSprite            = nullptr;
+    g_bgRectTransform      = nullptr;
+    g_customLoadingTexture = nullptr; // reset stale Unity object on re-login
     EnsureTextureLoaded();
   } catch (...) {
   }
@@ -436,6 +437,7 @@ void LoginSequence_Awake_Hook(auto original, void* _this)
   try {
     if (!Config::Get().loader_enabled)
       return;
+    g_customLoadingTexture = nullptr; // reset stale Unity object on re-login
     EnsureTextureLoaded();
     if (!g_customLoadingTexture)
       return;


### PR DESCRIPTION
This pull request makes a small but important change to the loading screen background transition feature by disabling it by default, and adds safeguards to reset the custom loading texture when the transition or login sequence is triggered. This helps prevent issues with stale Unity objects and ensures a more reliable loading screen experience.

**Loading Screen Transition Behavior:**

* The `transition_enabled` flag in `LoadingScreen` is now set to `false` by default, disabling the background transition feature unless explicitly enabled in the configuration.

**Stale Texture Reset Improvements:**

* In both `TransitionViewController_Awake_Hook` and `LoginSequence_Awake_Hook`, the global `g_customLoadingTexture` is reset to `nullptr` before loading a new texture, preventing stale Unity objects from persisting across transitions or re-logins. [[1]](diffhunk://#diff-653fb5a51f51705a29f95a11b247f21e65de9dd9ae0b7d18f981c33d5558e0e1R273) [[2]](diffhunk://#diff-653fb5a51f51705a29f95a11b247f21e65de9dd9ae0b7d18f981c33d5558e0e1R365)