### PR TITLE
fix: stabilize deferred space actions and set-course retries

### DIFF
--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -35,6 +35,7 @@
 
 #include <EASTL/vector.h>
 
+#include <cstdint>
 #include <iostream>
 #include <span>
 
@@ -47,6 +48,15 @@ static int  show_info_pending      = 0;
 
 bool force_space_action_next_frame = false;
 
+struct DeferredSpaceActionContext {
+  uint64_t             fleet_id        = 0;
+  PreScanTargetWidget* pre_scan_widget = nullptr;
+  BattleTargetData*    target_context  = nullptr;
+};
+
+static DeferredSpaceActionContext deferred_space_action_context;
+static uint64_t                   deferred_space_action_generation = 0;
+
 void     ChangeNavigationSection(SectionID sectionID);
 void     ExecuteSpaceAction(FleetBarViewController* fleet_bar);
 bool     DidExecuteRecall(FleetBarViewController* fleet_bar);
@@ -55,6 +65,8 @@ HullType GetHullTypeFromBattleTarget(BattleTargetData* context);
 void     GotoSection(SectionID sectionID, void* screen_data = nullptr);
 bool     CanHideViewers();
 bool     DidHideViewers();
+void     ClearDeferredSpaceAction();
+uint64_t DeferredSpaceActionGeneration();
 
 bool MoveOfficerCanvas(bool goLeft)
 {
@@ -66,6 +78,66 @@ bool MoveOfficerCanvas(bool goLeft)
   if (strcmp(((Il2CppObject*)(canvas))->klass->name, "OfficerShowcase_Canvas") == 0) {}
 
   return false;
+}
+
+template <typename T> bool IsViewerVisible(T* widget)
+{
+  return widget && widget->_visibilityController
+         && (widget->_visibilityController->_state == VisibilityState::Visible
+             || widget->_visibilityController->_state == VisibilityState::Show);
+}
+
+VisibilityState GetArmadaVisibilityState(ArmadaObjectViewerWidget* armada_widget)
+{
+  if (!armada_widget) {
+    return VisibilityState::Unknown;
+  }
+
+  if (armada_widget->_visibilityController) {
+    return armada_widget->_visibilityController->State;
+  }
+
+  spdlog::warn("ArmadaWidget has no visibility controller, using default Visible state");
+  return VisibilityState::Visible;
+}
+
+void ClearDeferredSpaceAction()
+{
+  force_space_action_next_frame = false;
+  deferred_space_action_context = {};
+  ++deferred_space_action_generation;
+}
+
+uint64_t DeferredSpaceActionGeneration()
+{
+  return deferred_space_action_generation;
+}
+
+void ArmDeferredSpaceAction(FleetPlayerData* fleet, PreScanTargetWidget* pre_scan_widget, BattleTargetData* context)
+{
+  if (!fleet || !pre_scan_widget) {
+    ClearDeferredSpaceAction();
+    return;
+  }
+
+  force_space_action_next_frame = true;
+  deferred_space_action_context = {fleet->Id, pre_scan_widget, context};
+  ++deferred_space_action_generation;
+}
+
+bool DeferredSpaceActionFleetMatches(FleetPlayerData* fleet)
+{
+  return force_space_action_next_frame && fleet && deferred_space_action_context.fleet_id == fleet->Id;
+}
+
+bool DeferredSpaceActionTargetMatches(FleetPlayerData* fleet, PreScanTargetWidget* pre_scan_widget,
+                                      BattleTargetData* context)
+{
+  if (!DeferredSpaceActionFleetMatches(fleet) || deferred_space_action_context.pre_scan_widget != pre_scan_widget) {
+    return false;
+  }
+
+  return !deferred_space_action_context.target_context || deferred_space_action_context.target_context == context;
 }
 
 void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
@@ -125,6 +197,9 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
   }
 
   if (ship_select_request != -1 && !Key::IsInputFocused()) {
+    // A deferred primary action belongs to the previous target/ship context.
+    // Switching ships should not let that retry fire against the next selection.
+    ClearDeferredSpaceAction();
 
     if (Key::HasShift()) {
       FleetPlayerData* foundDisco = nullptr;
@@ -378,9 +453,10 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
         auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
         if (fleet_bar) {
           bool was_forced = force_space_action_next_frame;
+          auto deferred_generation = DeferredSpaceActionGeneration();
           ExecuteSpaceAction(fleet_bar);
-          if (was_forced) {
-            force_space_action_next_frame = false;
+          if (was_forced && DeferredSpaceActionGeneration() == deferred_generation) {
+            ClearDeferredSpaceAction();
           }
         }
       }
@@ -574,7 +650,12 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
 
   auto action_queue = ActionQueueManager::Instance();
 
-  auto has_primary       = MapKey::IsDown(GameFunction::ActionPrimary) || force_space_action_next_frame;
+  auto has_physical_primary = MapKey::IsDown(GameFunction::ActionPrimary);
+  if (has_physical_primary && force_space_action_next_frame) {
+    ClearDeferredSpaceAction();
+  }
+
+  auto has_primary       = has_physical_primary || DeferredSpaceActionFleetMatches(fleet);
   auto has_repair        = MapKey::IsDown(GameFunction::ActionRepair);
   auto has_recall_cancel = MapKey::IsDown(GameFunction::ActionRecallCancel);
   auto has_secondary     = MapKey::IsDown(GameFunction::ActionSecondary);
@@ -583,35 +664,75 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
   auto has_recall =
       MapKey::IsDown(GameFunction::ActionRecall) && (!Config::Get().disable_preview_recall || !CanHideViewers());
 
+  const auto fleet_is_warping =
+      fleet->CurrentState == FleetState::WarpCharging || fleet->CurrentState == FleetState::Warping;
+
+  auto visible_pre_scan_target_count = 0;
+  auto mining_viewer_visible         = false;
+  auto star_node_viewer_visible      = false;
+  auto navigation_interaction_visible = false;
+
+  const auto collect_warp_cancel_context = [&]() {
+    for (auto pre_scan_widget : ObjectFinder<PreScanTargetWidget>::GetAll()) {
+      if (IsViewerVisible(pre_scan_widget)) {
+        ++visible_pre_scan_target_count;
+      }
+    }
+
+    auto mine_object_viewer_widget = ObjectFinder<MiningObjectViewerWidget>::Get();
+    mining_viewer_visible          = IsViewerVisible(mine_object_viewer_widget);
+
+    auto star_node_object_viewer_widget = ObjectFinder<StarNodeObjectViewerWidget>::Get();
+    star_node_viewer_visible            = star_node_object_viewer_widget && star_node_object_viewer_widget->Context;
+
+    navigation_interaction_visible = ObjectFinder<NavigationInteractionUIViewController>::Get() != nullptr;
+  };
+
   if (has_queue_clear) {
     action_queue->ClearQueue(fleet);
-  } else if (has_recall_cancel
-             && (fleet->CurrentState == FleetState::WarpCharging || fleet->CurrentState == FleetState::Warping)) {
-    fleet_controller->CancelButtonClicked();
+  } else if (has_recall_cancel && fleet_is_warping) {
+    collect_warp_cancel_context();
+    const auto suppress_mouse_warp_cancel =
+        Key::Down(KeyCode::Mouse1)
+        && (visible_pre_scan_target_count > 0 || mining_viewer_visible || star_node_viewer_visible
+            || navigation_interaction_visible);
+    if (!suppress_mouse_warp_cancel) {
+      fleet_controller->CancelButtonClicked();
+    }
   } else {
     auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
-    for (auto pre_scan_widget : all_pre_scan_widgets) {
-      if (pre_scan_widget
-          && (pre_scan_widget->_visibilityController->_state == VisibilityState::Visible
-              || pre_scan_widget->_visibilityController->_state == VisibilityState::Show)) {
+    auto mine_object_viewer_widget = ObjectFinder<MiningObjectViewerWidget>::Get();
+    auto mine_object_viewer_visible = IsViewerVisible(mine_object_viewer_widget);
+    auto armada_widget              = ObjectFinder<ArmadaObjectViewerWidget>::Get();
+    auto armada_state               = VisibilityState::Unknown;
+    auto armada_state_loaded        = false;
+    const auto get_armada_state = [&]() {
+      if (!armada_state_loaded) {
+        armada_state        = GetArmadaVisibilityState(armada_widget);
+        armada_state_loaded = true;
+      }
+      return armada_state;
+    };
+    auto queue_unlocked = has_queue && action_queue->IsQueueUnlocked();
 
-        if (auto mine_object_viewer_widget = ObjectFinder<MiningObjectViewerWidget>::Get();
-            mine_object_viewer_widget
-            && (mine_object_viewer_widget->_visibilityController->_state == VisibilityState::Visible
-                || mine_object_viewer_widget->_visibilityController->_state == VisibilityState::Show)) {
-          if (has_secondary) {
-            return pre_scan_widget->_scanEngageButtonsWidget->OnScanButtonClicked();
-          } else if (has_primary) {
+    for (auto pre_scan_widget : all_pre_scan_widgets) {
+      if (IsViewerVisible(pre_scan_widget)) {
+        auto scan_engage_buttons_widget = pre_scan_widget->_scanEngageButtonsWidget;
+        auto context                    = scan_engage_buttons_widget ? scan_engage_buttons_widget->Context : nullptr;
+        auto type                       = GetHullTypeFromBattleTarget(context);
+        auto deferred_primary_for_target = DeferredSpaceActionTargetMatches(fleet, pre_scan_widget, context);
+        auto has_primary_for_target      = has_physical_primary || deferred_primary_for_target;
+
+        if (mine_object_viewer_visible) {
+          if (has_secondary && scan_engage_buttons_widget) {
+            return scan_engage_buttons_widget->OnScanButtonClicked();
+          } else if (has_primary_for_target) {
             return mine_object_viewer_widget->MineClicked();
           }
         }
 
-        if (has_queue && action_queue->IsQueueUnlocked() && pre_scan_widget->_addToQueueButtonWidget
-            && pre_scan_widget->_scanEngageButtonsWidget) {
-          auto context = pre_scan_widget->_scanEngageButtonsWidget->Context;
-          auto type    = GetHullTypeFromBattleTarget(context);
-
-          if (type != HullType::ArmadaTarget && (type != HullType::Any || force_space_action_next_frame)) {
+        if (queue_unlocked && pre_scan_widget->_addToQueueButtonWidget && scan_engage_buttons_widget) {
+          if (type != HullType::ArmadaTarget && (type != HullType::Any || deferred_primary_for_target)) {
             if (pre_scan_widget->_addToQueueButtonWidget->isActiveAndEnabled) {
               auto listener = pre_scan_widget->_addToQueueButtonWidget->SemaphoreListener;
               if (listener && !action_queue->IsQueueFull(fleet)) {
@@ -625,45 +746,26 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
             }
 
             if (type == HullType::Any) {
-              force_space_action_next_frame = true;
+              ArmDeferredSpaceAction(fleet, pre_scan_widget, context);
               return;
             }
           }
         }
 
-        if (has_secondary) {
-          return pre_scan_widget->_scanEngageButtonsWidget->OnScanButtonClicked();
+        if (has_secondary && scan_engage_buttons_widget) {
+          return scan_engage_buttons_widget->OnScanButtonClicked();
         }
 
-        if (has_primary && pre_scan_widget->_scanEngageButtonsWidget
-            && pre_scan_widget->_scanEngageButtonsWidget->enabled) {
-          auto context = pre_scan_widget->_scanEngageButtonsWidget->Context;
-          auto type    = GetHullTypeFromBattleTarget(context);
-
-          // Try once more in X frames if we get ANY
-          // in-case of failed to navgitate error?
-          auto armada_widget = ObjectFinder<ArmadaObjectViewerWidget>::Get();
-          auto armada_state  = VisibilityState::Unknown;
-
-          if (armada_widget) {
-            if (armada_widget->_visibilityController) {
-              armada_state = armada_widget->_visibilityController->State;
-            } else {
-              spdlog::warn("ArmadaWidget has no visibility controller, using default Visible state");
-              armada_state = VisibilityState::Visible;
-            }
-          }
-
+        if (has_primary_for_target && scan_engage_buttons_widget && scan_engage_buttons_widget->enabled) {
           auto canActionPrimary = type != HullType::Any;
+          const auto current_armada_state = get_armada_state();
           if (type == HullType::ArmadaTarget
-              && (armada_state == VisibilityState::Visible || armada_state == VisibilityState::Show)) {
+              && (current_armada_state == VisibilityState::Visible || current_armada_state == VisibilityState::Show)) {
             canActionPrimary = false;
-          } else if (force_space_action_next_frame) {
+          } else if (deferred_primary_for_target) {
             canActionPrimary = true;
           }
 
-          // Try once more in X frames if we get ANY
-          // in-case of failed to navgitate error?
           if (canActionPrimary) {
             if (type == HullType::ArmadaTarget) {
               if (pre_scan_widget->_armadaAttackButton && pre_scan_widget->_armadaAttackButton->isActiveAndEnabled) {
@@ -676,53 +778,41 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
                 }
                 return;
               }
-              pre_scan_widget->_scanEngageButtonsWidget->OnArmadaButtonClicked();
+              scan_engage_buttons_widget->OnArmadaButtonClicked();
             } else {
-              pre_scan_widget->_scanEngageButtonsWidget->OnEngageButtonClicked();
+              scan_engage_buttons_widget->OnEngageButtonClicked();
             }
             return;
-          } else if (type == HullType::Any) {
-            force_space_action_next_frame = true;
+          } else if (type == HullType::Any && has_physical_primary) {
+            ArmDeferredSpaceAction(fleet, pre_scan_widget, context);
             return;
           }
         }
       }
     }
 
-    if (auto mine_object_viewer_widget = ObjectFinder<MiningObjectViewerWidget>::Get();
-        mine_object_viewer_widget
-        && (mine_object_viewer_widget->_visibilityController->_state == VisibilityState::Visible
-            || mine_object_viewer_widget->_visibilityController->_state == VisibilityState::Show)) {
+    if (mine_object_viewer_visible) {
       if (has_secondary) {
-        if (mine_object_viewer_widget->_scanEngageButtonsWidget->Context) {
-          return mine_object_viewer_widget->_scanEngageButtonsWidget->OnScanButtonClicked();
+        auto scan_engage_buttons_widget = mine_object_viewer_widget->_scanEngageButtonsWidget;
+        if (scan_engage_buttons_widget && scan_engage_buttons_widget->Context) {
+          return scan_engage_buttons_widget->OnScanButtonClicked();
         }
-      } else if (has_primary) {
+      } else if (has_physical_primary) {
         return mine_object_viewer_widget->MineClicked();
       }
     } else if (auto star_node_object_viewer_widget = ObjectFinder<StarNodeObjectViewerWidget>::Get();
                star_node_object_viewer_widget && star_node_object_viewer_widget->Context) {
       if (has_secondary) {
         star_node_object_viewer_widget->OnViewButtonActivation();
-      } else if (has_primary) {
+      } else if (has_physical_primary) {
         star_node_object_viewer_widget->InitiateWarp();
       }
     } else if (auto navigation_ui_controller = ObjectFinder<NavigationInteractionUIViewController>::Get();
-               navigation_ui_controller && has_primary) {
-      auto armada_widget = ObjectFinder<ArmadaObjectViewerWidget>::Get();
-      auto armada_state  = VisibilityState::Unknown;
-
-      if (armada_widget) {
-        if (armada_widget->_visibilityController) {
-          armada_state = armada_widget->_visibilityController->State;
-        } else {
-          spdlog::warn("ArmadaWidget has no visibility controller, using default Visible state");
-          armada_state = VisibilityState::Visible;
-        }
-      }
-
-      spdlog::info("have armada? {}, State {}", (armada_widget ? "Yes" : "No"), (int)armada_state);
-      if (armada_widget && (armada_state == VisibilityState::Visible || armada_state == VisibilityState::Show)) {
+               navigation_ui_controller && has_physical_primary) {
+      const auto current_armada_state = get_armada_state();
+      spdlog::info("have armada? {}, State {}", (armada_widget ? "Yes" : "No"), (int)current_armada_state);
+      if (armada_widget
+          && (current_armada_state == VisibilityState::Visible || current_armada_state == VisibilityState::Show)) {
         auto button = armada_widget->__get__joinContext();
         if (button && button->Interactable) {
           armada_widget->ValidateThenJoinArmada();

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -35,6 +35,7 @@
 
 #include <EASTL/vector.h>
 
+#include <chrono>
 #include <cstdint>
 #include <iostream>
 #include <span>
@@ -56,6 +57,15 @@ struct DeferredSpaceActionContext {
 
 static DeferredSpaceActionContext deferred_space_action_context;
 static uint64_t                   deferred_space_action_generation = 0;
+
+struct SetCourseSubmission {
+  uintptr_t                             target_identity = 0;
+  std::chrono::steady_clock::time_point submitted_at{};
+};
+
+constexpr auto kDuplicateSetCourseSuppressionWindow = std::chrono::milliseconds(750);
+
+static SetCourseSubmission last_set_course_submission;
 
 void     ChangeNavigationSection(SectionID sectionID);
 void     ExecuteSpaceAction(FleetBarViewController* fleet_bar);
@@ -138,6 +148,59 @@ bool DeferredSpaceActionTargetMatches(FleetPlayerData* fleet, PreScanTargetWidge
   }
 
   return !deferred_space_action_context.target_context || deferred_space_action_context.target_context == context;
+}
+
+uintptr_t NavigationTargetIdentity(NavigationInteractionUIViewController* navigation_ui_controller)
+{
+  if (!navigation_ui_controller) {
+    return 0;
+  }
+
+  auto context = navigation_ui_controller->CanvasContext;
+  if (!context) {
+    return reinterpret_cast<uintptr_t>(navigation_ui_controller);
+  }
+
+  if (context->Poi) {
+    return reinterpret_cast<uintptr_t>(context->Poi);
+  }
+
+  if (context->LocationTranslationId > 0) {
+    return static_cast<uintptr_t>(context->LocationTranslationId);
+  }
+
+  return reinterpret_cast<uintptr_t>(context);
+}
+
+bool ShouldSuppressDuplicateSetCourse(NavigationInteractionUIViewController* navigation_ui_controller)
+{
+  const auto target_identity = NavigationTargetIdentity(navigation_ui_controller);
+  const auto now             = std::chrono::steady_clock::now();
+
+  if (last_set_course_submission.target_identity == target_identity
+      && last_set_course_submission.submitted_at != std::chrono::steady_clock::time_point{}) {
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now - last_set_course_submission.submitted_at);
+    if (elapsed <= kDuplicateSetCourseSuppressionWindow) {
+      spdlog::debug("[Hotkeys] Suppressed duplicate set-course target={} elapsed_ms={}",
+                    target_identity,
+                    elapsed.count());
+      return true;
+    }
+  }
+
+  last_set_course_submission = {target_identity, now};
+  return false;
+}
+
+void NavigationInteractionUIViewController_OnSetCourseButtonClick_Hook(auto original,
+                                                                       NavigationInteractionUIViewController* _this)
+{
+  if (ShouldSuppressDuplicateSetCourse(_this)) {
+    return;
+  }
+
+  original(_this);
 }
 
 void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
@@ -969,6 +1032,19 @@ void InstallHotkeyHooks()
       ErrorMsg::MissingMethod("PreScanTargetWidget", "ShowWithFleet");
     } else {
       SPUD_STATIC_DETOUR(show_with_fleet_ptr, ShowWithFleet_Hook);
+    }
+  }
+
+  static auto navigation_interaction_helper =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Navigation", "NavigationInteractionUIViewController");
+  if (!navigation_interaction_helper.isValidHelper()) {
+    ErrorMsg::MissingHelper("Navigation", "NavigationInteractionUIViewController");
+  } else {
+    auto set_course_button_click = navigation_interaction_helper.GetMethod("OnSetCourseButtonClick");
+    if (set_course_button_click == nullptr) {
+      ErrorMsg::MissingMethod("NavigationInteractionUIViewController", "OnSetCourseButtonClick");
+    } else {
+      SPUD_STATIC_DETOUR(set_course_button_click, NavigationInteractionUIViewController_OnSetCourseButtonClick_Hook);
     }
   }
 }

--- a/mods/src/prime/NavigationInteractionUIContext.h
+++ b/mods/src/prime/NavigationInteractionUIContext.h
@@ -1,14 +1,87 @@
 #pragma once
 
+#include <cstdint>
+
 #include <il2cpp/il2cpp_helper.h>
 
 struct NavigationInteractionUIContext {
 public:
+  __declspec(property(get = __get_ContextDataState)) int ContextDataState;
+  __declspec(property(get = __get_InputInteractionType)) int InputInteractionType;
+  __declspec(property(get = __get_UserId)) Il2CppString* UserId;
+  __declspec(property(get = __get_IsMarauder)) bool IsMarauder;
+  __declspec(property(get = __get_ThreatLevel)) int ThreatLevel;
+  __declspec(property(get = __get_ValidNavigationInput)) bool ValidNavigationInput;
+  __declspec(property(get = __get_ShowSetCourseArm)) bool ShowSetCourseArm;
+  __declspec(property(get = __get_LocationTranslationId)) int64_t LocationTranslationId;
+  __declspec(property(get = __get_Poi)) void* Poi;
+
 private:
   static IL2CppClassHelper& get_class_helper()
   {
     static auto class_helper =
         il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Navigation", "NavigationInteractionUIContext");
     return class_helper;
+  }
+
+public:
+  int __get_ContextDataState()
+  {
+    static auto prop = get_class_helper().GetProperty("ContextDataState");
+    if (auto* value = prop.Get<int>(this); value) {
+      return *value;
+    }
+    return -1;
+  }
+
+  int __get_InputInteractionType()
+  {
+    static auto prop = get_class_helper().GetProperty("InputInteractionType");
+    if (auto* value = prop.Get<int>(this); value) {
+      return *value;
+    }
+    return -1;
+  }
+
+  Il2CppString* __get_UserId()
+  {
+    static auto field = get_class_helper().GetField("UserId").offset();
+    return *(Il2CppString**)((uintptr_t)this + field);
+  }
+
+  bool __get_IsMarauder()
+  {
+    static auto field = get_class_helper().GetField("IsMarauder").offset();
+    return *(bool*)((uintptr_t)this + field);
+  }
+
+  int __get_ThreatLevel()
+  {
+    static auto field = get_class_helper().GetField("ThreatLevel").offset();
+    return *(int*)((uintptr_t)this + field);
+  }
+
+  bool __get_ValidNavigationInput()
+  {
+    static auto field = get_class_helper().GetField("ValidNavigationInput").offset();
+    return *(bool*)((uintptr_t)this + field);
+  }
+
+  bool __get_ShowSetCourseArm()
+  {
+    static auto field = get_class_helper().GetField("ShowSetCourseArm").offset();
+    return *(bool*)((uintptr_t)this + field);
+  }
+
+  int64_t __get_LocationTranslationId()
+  {
+    static auto field = get_class_helper().GetField("LocationTranslationId").offset();
+    return *(int64_t*)((uintptr_t)this + field);
+  }
+
+  void* __get_Poi()
+  {
+    static auto field = get_class_helper().GetField("Poi").offset();
+    return *(void**)((uintptr_t)this + field);
   }
 };

--- a/mods/src/prime/NavigationInteractionUIViewController.h
+++ b/mods/src/prime/NavigationInteractionUIViewController.h
@@ -2,7 +2,11 @@
 
 #include <il2cpp/il2cpp_helper.h>
 
-struct NavigationInteractionUIViewController {
+#include "NavigationInteractionUIContext.h"
+#include "ViewController.h"
+
+struct NavigationInteractionUIViewController
+    : public ViewController<NavigationInteractionUIContext, NavigationInteractionUIViewController> {
 public:
   void OnSetCourseButtonClick()
   {
@@ -19,5 +23,6 @@ public:
   }
 
 private:
+  friend struct ViewController<NavigationInteractionUIContext, NavigationInteractionUIViewController>;
   friend class ObjectFinder<NavigationInteractionUIViewController>;
 };


### PR DESCRIPTION
## Reviewer Quick Path

This is a standalone bug-fix draft from `main`. The normal GitHub diff is the right review view.

It is listed after the `#136` refactor stack for context, but it is not a merge dependency on that cumulative refactor stack.

## Summary

- replace the context-free deferred primary retry with deferred action state scoped to the current fleet and target context
- clear deferred retries when ship selection changes, when a real primary press supersedes the deferred retry, or when the next frame does not consume the same fleet/target context
- suppress rapid duplicate same-target set-course submissions at `NavigationInteractionUIViewController.OnSetCourseButtonClick`
- expose the navigation interaction context fields needed to key that suppression on the actual target identity in the current `main`-branch wrapper surface

## Review Context

For the broader hotkey work, review this sequence in order:

1. `#136` `refactor: replace hotkey if/else chain with static dispatch table`
2. `#166` `refactor: extract hotkey router from hook detours`
3. `#167` `refactor: extract hotkey UI concern modules`
4. `#168` `refactor: extract hotkey fleet actions`
5. this PR

This order is review context, not a merge dependency.

## Build / Branch Order

- this branch is intentionally standalone: `fix/deferred-space-actions`
- it branches directly from `main`
- it does not depend on the cumulative `#136 -> #166 -> #167 -> #168` refactor stack
- it ports the deferred-space-action behavior fix into the current monolithic `hotkeys.cc` shape on `main`

## Validation

Validated locally on Windows in `releasedbg`:

```bash
xmake b -y mods
git diff --check
pwsh -NoProfile -File D:\dev\stfc-mod\.ax\ax.ps1 -RepoRoot D:\dev\netniv\stfc-mod cycle -BuildMode releasedbg
```

Manual in-game retest after the AX deploy exercised the previously noisy set-course path, and the user reported the result was much cleaner.