### PR TITLE
feat: add fleet alerts and notification policy

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -552,6 +552,12 @@ disable_toast_banners = false
 # Specifies types of banners you don't want to see (comma separated)
 disabled_banner_types = ""
 
+# System notifications for in-game events. Comma-separated list of toast types
+# to deliver as OS-level notifications (Windows toast). Uses the same type names
+# as disabled_banner_types. Empty string = no notifications.
+# Example: "Victory, Defeat, IncomingAttack, StationBattle"
+notify_banner_types = ""
+
 # Subgroup: Chat
 # --------------
 

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -179,6 +179,78 @@ system_zoom_preset_5 = 5000.0
 # This controls the maximum zoom distance in System View. Default is 2500. Higher values increase label distance
 zoom = 5000.0
 
+#  <[=============================================]>
+#
+#       *   *         *    *               ***
+#       **  *   ***  ***         *   ***   *
+#       * * *  *   *  *    *    **  *   *  ****
+#       *  **  *   *  *    *    *   *****    *
+#       *   *   ***    **  *   *     ***   ****
+#
+#  <[=============================================]>
+
+[notifications]
+# Master switch - must be true for any system notifications to fire.
+# When false, the individual notification toggles below are ignored.
+notifications_enabled = false
+
+# Supported: Battle notifications (fully parsed with player/ship detail)
+notifications_victory = true
+notifications_defeat = true
+notifications_partial_victory = true
+notifications_station_victory = false
+notifications_station_defeat = false
+notifications_station_battle = false
+notifications_incoming_attack = false
+notifications_fleet_battle = false
+notifications_armada_battle_won = false
+notifications_armada_battle_lost = false
+notifications_assault_victory = false
+notifications_assault_defeat = false
+
+# Supported: Armada notifications (parsed with alliance/owner detail)
+notifications_armada_created = true
+notifications_armada_canceled = true
+
+# Supported: Event notifications (best-effort text resolution)
+notifications_tournament = true
+notifications_chained_event_scored = true
+
+# Supported: Fleet notifications (fleet-bar transitions and mining depletion)
+notifications_fleet_arrived_in_system = false
+notifications_fleet_started_mining = false
+notifications_fleet_node_depleted = false
+notifications_fleet_docked = false
+
+# Experimental - these use generic text resolution and may show raw placeholders
+notifications_standard = false
+notifications_faction_warning = false
+notifications_faction_level_up = false
+notifications_faction_level_down = false
+notifications_faction_discovered = false
+notifications_incoming_attack_faction = false
+notifications_armada_incoming_attack = false
+notifications_diplomacy_updated = false
+notifications_joined_takeover = false
+notifications_competitor_joined_takeover = false
+notifications_abandoned_territory = false
+notifications_takeover_victory = false
+notifications_takeover_defeat = false
+notifications_treasury_progress = false
+notifications_treasury_full = false
+notifications_achievement = false
+notifications_challenge_complete = false
+notifications_challenge_failed = false
+notifications_strike_hit = false
+notifications_strike_defeat = false
+notifications_warchest_progress = false
+notifications_warchest_full = false
+notifications_arena_time_left = false
+notifications_fleet_preset_applied = false
+notifications_surge_warmup_ended = false
+notifications_surge_hostile_group_defeated = false
+notifications_surge_time_left = false
+
 #  <[=====================================================]>
 #
 #       ****           *            *

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -705,6 +705,29 @@ void Config::Load()
 
   parsed["ui"].as_table()->insert_or_assign("disabled_banner_types", bannerString);
 
+  // Parse notify_banner_types using the same bannerTypes lookup table
+  auto notify_banner_types_str =
+      get_config_or_default<std::string>(config, parsed, "ui", "notify_banner_types", DCU::notify_banner_types, write_log);
+
+  std::vector<std::string> notify_types = StrSplit(notify_banner_types_str, ',');
+  std::string              notifyString;
+
+  for (const auto& [key, value] : bannerTypes) {
+    auto upper_key = AsciiStrToUpper(key);
+    for (const std::string_view _type : notify_types) {
+      auto stripped_type = StripLeadingAsciiWhitespace(_type);
+      auto upper_type    = AsciiStrToUpper(stripped_type);
+      if (upper_key == upper_type) {
+        this->notify_banner_types.emplace_back(value);
+        if (!notifyString.empty()) notifyString.append(", ");
+        notifyString.append(key);
+      }
+    }
+  }
+
+  spdlog::debug("Final notify banner types: {}", notifyString);
+  parsed["ui"].as_table()->insert_or_assign("notify_banner_types", notifyString);
+
   spdlog::debug("");
 
   //if (this->enable_experimental) {

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -499,6 +499,7 @@ void Config::Load()
   this->installResolutionListFix = get_config_or_default(config, parsed, "patches", "resolutionlistfix", DCP::resolutionlistfix, write_config);
   this->installSyncPatches       = get_config_or_default(config, parsed, "patches", "syncpatches", DCP::syncpatches, write_config);
   this->installObjectTracker       = get_config_or_default(config, parsed, "patches", "objecttracker", DCP::objecttracker, write_config);
+  this->installFleetArrivalHooks   = get_config_or_default(config, parsed, "patches", "fleetarrivalhooks", DCP::fleetarrivalhooks, write_config);
   this->installLoadingScreenBgHooks = get_config_or_default(config, parsed, "patches", "loadingscreenbghooks", DCP::loadingscreenbghooks, write_config);
   spdlog::debug("");
 #else
@@ -517,6 +518,7 @@ void Config::Load()
   this->installResolutionListFix          = false; // this patch does not work after unity 6 update
   this->installSyncPatches                = true;
   this->installObjectTracker              = true;
+  this->installFleetArrivalHooks          = true;
   this->installLoadingScreenBgHooks       = true;
 #endif
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -19,12 +19,86 @@
 
 namespace DCP = DefaultConfig::Patches;
 namespace DCG = DefaultConfig::Graphics;
+namespace DCN = DefaultConfig::Notifications;
 namespace DCC = DefaultConfig::Control;
 namespace DCU = DefaultConfig::UI;
 namespace DCBS = DefaultConfig::Buffs;
 namespace DCS = DefaultConfig::Sync;
 namespace DCSC = DefaultConfig::SystemConfig;
 namespace DCSH = DefaultConfig::Shortcuts;
+
+struct NotificationBoolConfigSpec {
+  const char* key;
+  bool NotificationConfig::* member;
+  bool default_value;
+};
+
+struct NotificationToggleSpec {
+  const char* key;
+  int         toast_state;
+  bool        default_value;
+};
+
+static constexpr NotificationBoolConfigSpec notificationBoolConfigSpecs[] = {
+    {"notifications_enabled", &NotificationConfig::enabled, DCN::enabled},
+    {"notifications_fleet_arrived_in_system", &NotificationConfig::fleet_arrived_in_system,
+     DCN::Fleet::arrived_in_system},
+    {"notifications_fleet_started_mining", &NotificationConfig::fleet_started_mining,
+     DCN::Fleet::started_mining},
+    {"notifications_fleet_node_depleted", &NotificationConfig::fleet_node_depleted, DCN::Fleet::node_depleted},
+    {"notifications_fleet_docked", &NotificationConfig::fleet_docked, DCN::Fleet::docked},
+};
+
+static constexpr NotificationToggleSpec notificationToggleSpecs[] = {
+    {"notifications_standard", ToastState::Standard, DCN::Experimental::standard},
+    {"notifications_faction_warning", ToastState::FactionWarning, DCN::Experimental::faction_warning},
+    {"notifications_faction_level_up", ToastState::FactionLevelUp, DCN::Experimental::faction_level_up},
+    {"notifications_faction_level_down", ToastState::FactionLevelDown, DCN::Experimental::faction_level_down},
+    {"notifications_faction_discovered", ToastState::FactionDiscovered, DCN::Experimental::faction_discovered},
+    {"notifications_incoming_attack", ToastState::IncomingAttack, DCN::Battle::incoming_attack},
+    {"notifications_incoming_attack_faction", ToastState::IncomingAttackFaction,
+     DCN::Experimental::incoming_attack_faction},
+    {"notifications_fleet_battle", ToastState::FleetBattle, DCN::Battle::fleet_battle},
+    {"notifications_station_battle", ToastState::StationBattle, DCN::Battle::station_battle},
+    {"notifications_station_victory", ToastState::StationVictory, DCN::Battle::station_victory},
+    {"notifications_victory", ToastState::Victory, DCN::Battle::victory},
+    {"notifications_defeat", ToastState::Defeat, DCN::Battle::defeat},
+    {"notifications_station_defeat", ToastState::StationDefeat, DCN::Battle::station_defeat},
+    {"notifications_tournament", ToastState::Tournament, DCN::Events::tournament},
+    {"notifications_armada_created", ToastState::ArmadaCreated, DCN::Armada::created},
+    {"notifications_armada_canceled", ToastState::ArmadaCanceled, DCN::Armada::canceled},
+    {"notifications_armada_incoming_attack", ToastState::ArmadaIncomingAttack,
+     DCN::Experimental::armada_incoming_attack},
+    {"notifications_armada_battle_won", ToastState::ArmadaBattleWon, DCN::Battle::armada_battle_won},
+    {"notifications_armada_battle_lost", ToastState::ArmadaBattleLost, DCN::Battle::armada_battle_lost},
+    {"notifications_diplomacy_updated", ToastState::DiplomacyUpdated, DCN::Experimental::diplomacy_updated},
+    {"notifications_joined_takeover", ToastState::JoinedTakeover, DCN::Experimental::joined_takeover},
+    {"notifications_competitor_joined_takeover", ToastState::CompetitorJoinedTakeover,
+     DCN::Experimental::competitor_joined_takeover},
+    {"notifications_abandoned_territory", ToastState::AbandonedTerritory, DCN::Experimental::abandoned_territory},
+    {"notifications_takeover_victory", ToastState::TakeoverVictory, DCN::Experimental::takeover_victory},
+    {"notifications_takeover_defeat", ToastState::TakeoverDefeat, DCN::Experimental::takeover_defeat},
+    {"notifications_treasury_progress", ToastState::TreasuryProgress, DCN::Experimental::treasury_progress},
+    {"notifications_treasury_full", ToastState::TreasuryFull, DCN::Experimental::treasury_full},
+    {"notifications_achievement", ToastState::Achievement, DCN::Experimental::achievement},
+    {"notifications_assault_victory", ToastState::AssaultVictory, DCN::Battle::assault_victory},
+    {"notifications_assault_defeat", ToastState::AssaultDefeat, DCN::Battle::assault_defeat},
+    {"notifications_challenge_complete", ToastState::ChallengeComplete, DCN::Experimental::challenge_complete},
+    {"notifications_challenge_failed", ToastState::ChallengeFailed, DCN::Experimental::challenge_failed},
+    {"notifications_strike_hit", ToastState::StrikeHit, DCN::Experimental::strike_hit},
+    {"notifications_strike_defeat", ToastState::StrikeDefeat, DCN::Experimental::strike_defeat},
+    {"notifications_warchest_progress", ToastState::WarchestProgress, DCN::Experimental::warchest_progress},
+    {"notifications_warchest_full", ToastState::WarchestFull, DCN::Experimental::warchest_full},
+    {"notifications_partial_victory", ToastState::PartialVictory, DCN::Battle::partial_victory},
+    {"notifications_arena_time_left", ToastState::ArenaTimeLeft, DCN::Experimental::arena_time_left},
+    {"notifications_chained_event_scored", ToastState::ChainedEventScored, DCN::Events::chained_event_scored},
+    {"notifications_fleet_preset_applied", ToastState::FleetPresetApplied,
+     DCN::Experimental::fleet_preset_applied},
+    {"notifications_surge_warmup_ended", ToastState::SurgeWarmUpEnded, DCN::Experimental::surge_warmup_ended},
+    {"notifications_surge_hostile_group_defeated", ToastState::SurgeHostileGroupDefeated,
+     DCN::Experimental::surge_hostile_group_defeated},
+    {"notifications_surge_time_left", ToastState::SurgeTimeLeft, DCN::Experimental::surge_time_left},
+};
 
 static const eastl::tuple<const char*, int> bannerTypes[] = {
     {"Standard", ToastState::Standard},
@@ -729,6 +803,72 @@ void Config::Load()
 
   spdlog::debug("Final notify banner types: {}", notifyString);
   parsed["ui"].as_table()->insert_or_assign("notify_banner_types", notifyString);
+
+  auto*      notifications_table = config["notifications"].as_table();
+  const bool has_explicit_notification_toggles =
+      notifications_table
+      && std::ranges::any_of(notificationToggleSpecs,
+                             [notifications_table](const auto& spec) { return notifications_table->contains(spec.key); });
+
+  auto*       ui_table = config["ui"].as_table();
+  std::string legacy_notify_banner_types;
+  bool        has_legacy_notify_banner_types = false;
+  if (ui_table) {
+    if (auto notify_on_value = config["ui"]["notify_on_banner_types"].value<std::string>();
+        notify_on_value.has_value()) {
+      legacy_notify_banner_types     = notify_on_value.value();
+      has_legacy_notify_banner_types = true;
+    } else if (auto notify_value = config["ui"]["notify_banner_types"].value<std::string>(); notify_value.has_value()) {
+      legacy_notify_banner_types     = notify_value.value();
+      has_legacy_notify_banner_types = true;
+    }
+  }
+
+  const bool use_legacy_notify_allowlist = has_legacy_notify_banner_types && !has_explicit_notification_toggles;
+
+  for (const auto& spec : notificationBoolConfigSpecs) {
+    this->notifications.*(spec.member) =
+        get_config_or_default(config, parsed, "notifications", spec.key, spec.default_value, write_log);
+  }
+
+  this->notifications.ClearToastStates();
+  for (const auto& spec : notificationToggleSpecs) {
+    const bool enabled =
+        get_config_or_default(config, parsed, "notifications", spec.key,
+                              use_legacy_notify_allowlist ? false : spec.default_value, write_log);
+    this->notifications.SetToastStateEnabled(spec.toast_state, enabled);
+  }
+
+  if (use_legacy_notify_allowlist) {
+    if (!(notifications_table && notifications_table->contains("notifications_enabled"))) {
+      this->notifications.enabled = true;
+      parsed["notifications"].as_table()->insert_or_assign("notifications_enabled", true);
+    }
+
+    this->notifications.ClearToastStates();
+
+    for (const auto& [key, value] : bannerTypes) {
+      auto upper_key = AsciiStrToUpper(key);
+      for (const std::string_view raw_type : notify_types) {
+        auto stripped_type = StripLeadingAsciiWhitespace(raw_type);
+        auto upper_type    = AsciiStrToUpper(stripped_type);
+        if (upper_key == upper_type) {
+          this->notifications.SetToastStateEnabled(value, true);
+        }
+      }
+    }
+
+    for (const auto& spec : notificationToggleSpecs) {
+      parsed["notifications"].as_table()->insert_or_assign(spec.key,
+                                                           this->notifications.EnabledForToastState(spec.toast_state));
+    }
+
+    spdlog::warn("Deprecation Warning: [ui].notify_on_banner_types / [ui].notify_banner_types is deprecated. Migrate "
+                 "to [notifications].");
+  } else if (has_legacy_notify_banner_types) {
+    spdlog::warn(
+        "Ignoring deprecated [ui] notification allowlist because explicit [notifications] toggles are present.");
+  }
 
   spdlog::debug("");
 

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -160,6 +160,7 @@ public:
 
   bool             borderless_fullscreen;
   std::vector<int> disabled_banner_types;
+  std::vector<int> notify_banner_types;
 
   int  extend_donation_max;
   bool extend_donation_slider;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -203,6 +203,7 @@ public:
   bool installResolutionListFix;
   bool installSyncPatches;
   bool installObjectTracker;
+  bool installFleetArrivalHooks;
 
   std::string config_settings_url;
   std::string config_assets_url_override;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <bitset>
 #include <map>
 #include <string>
 #include <vector>
@@ -103,6 +104,44 @@ public:
   std::string token;
 };
 
+class NotificationConfig
+{
+public:
+  static constexpr size_t MaxToastStates = 64;
+
+  bool enabled                 = false;
+  bool fleet_arrived_in_system = false;
+  bool fleet_started_mining    = false;
+  bool fleet_node_depleted     = false;
+  bool fleet_docked            = false;
+
+  [[nodiscard]] bool EnabledForToastState(int state) const
+  {
+    if (state < 0 || static_cast<size_t>(state) >= toast_state_enabled.size()) {
+      return false;
+    }
+
+    return toast_state_enabled.test(static_cast<size_t>(state));
+  }
+
+  void SetToastStateEnabled(int state, bool isEnabled)
+  {
+    if (state < 0 || static_cast<size_t>(state) >= toast_state_enabled.size()) {
+      return;
+    }
+
+    toast_state_enabled.set(static_cast<size_t>(state), isEnabled);
+  }
+
+  void ClearToastStates()
+  {
+    toast_state_enabled.reset();
+  }
+
+private:
+  std::bitset<MaxToastStates> toast_state_enabled{};
+};
+
 class Config final
 {
 public:
@@ -157,6 +196,7 @@ public:
   float system_zoom_preset_4;
   float system_zoom_preset_5;
   float transition_time;
+  NotificationConfig notifications;
 
   bool             borderless_fullscreen;
   std::vector<int> disabled_banner_types;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -200,6 +200,7 @@ namespace UI
   constexpr bool        disable_toast_banners       = false;
   constexpr bool        disable_veil_chat           = false;
   constexpr const char* disabled_banner_types       = "";
+  constexpr const char* notify_banner_types         = "";
   constexpr auto        extend_donation_max         = 80;
   constexpr bool        extend_donation_slider      = true;
   constexpr bool        show_armada_cargo           = true;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -58,6 +58,7 @@ namespace Patches
   constexpr bool improveresponsivenesshooks = true;
   constexpr bool miscpatches                = true;
   constexpr bool objecttracker              = true;
+  constexpr bool fleetarrivalhooks          = true;
   constexpr bool panhooks                   = true;
   constexpr bool resolutionlistfix          = false;
   constexpr bool syncpatches                = true;
@@ -68,7 +69,6 @@ namespace Patches
   constexpr bool zoomhooks                  = true;
   constexpr bool loadingscreenbghooks       = true; // ENABLED - new BlurController approach
 } // namespace Patches
-
 namespace Shortcuts
 {
   constexpr const char* toggle_queue          = "CTRL-Q";

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -49,6 +49,78 @@ namespace Graphics
   constexpr const char* loader_image                = "";   // Empty = use embedded fallback
 } // namespace Graphics
 
+namespace Notifications
+{
+  constexpr bool enabled = false;
+
+  namespace Battle
+  {
+    constexpr bool victory            = true;
+    constexpr bool defeat             = true;
+    constexpr bool partial_victory    = true;
+    constexpr bool station_victory    = false;
+    constexpr bool station_defeat     = false;
+    constexpr bool station_battle     = false;
+    constexpr bool incoming_attack    = false;
+    constexpr bool fleet_battle       = false;
+    constexpr bool armada_battle_won  = false;
+    constexpr bool armada_battle_lost = false;
+    constexpr bool assault_victory    = false;
+    constexpr bool assault_defeat     = false;
+  } // namespace Battle
+
+  namespace Armada
+  {
+    constexpr bool created  = true;
+    constexpr bool canceled = true;
+  } // namespace Armada
+
+  namespace Events
+  {
+    constexpr bool tournament           = true;
+    constexpr bool chained_event_scored = true;
+  } // namespace Events
+
+  namespace Experimental
+  {
+    constexpr bool standard                     = false;
+    constexpr bool faction_warning              = false;
+    constexpr bool faction_level_up             = false;
+    constexpr bool faction_level_down           = false;
+    constexpr bool faction_discovered           = false;
+    constexpr bool incoming_attack_faction      = false;
+    constexpr bool armada_incoming_attack       = false;
+    constexpr bool diplomacy_updated            = false;
+    constexpr bool joined_takeover              = false;
+    constexpr bool competitor_joined_takeover   = false;
+    constexpr bool abandoned_territory          = false;
+    constexpr bool takeover_victory             = false;
+    constexpr bool takeover_defeat              = false;
+    constexpr bool treasury_progress            = false;
+    constexpr bool treasury_full                = false;
+    constexpr bool achievement                  = false;
+    constexpr bool challenge_complete           = false;
+    constexpr bool challenge_failed             = false;
+    constexpr bool strike_hit                   = false;
+    constexpr bool strike_defeat                = false;
+    constexpr bool warchest_progress            = false;
+    constexpr bool warchest_full                = false;
+    constexpr bool arena_time_left              = false;
+    constexpr bool fleet_preset_applied         = false;
+    constexpr bool surge_warmup_ended           = false;
+    constexpr bool surge_hostile_group_defeated = false;
+    constexpr bool surge_time_left              = false;
+  } // namespace Experimental
+
+  namespace Fleet
+  {
+    constexpr bool arrived_in_system = false;
+    constexpr bool started_mining    = false;
+    constexpr bool node_depleted     = false;
+    constexpr bool docked            = false;
+  } // namespace Fleet
+} // namespace Notifications
+
 namespace Patches
 {
   constexpr bool bufffixhooks               = true;

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -1,0 +1,195 @@
+#include "patches/battle_notify_parser.h"
+
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/BattleResultHeader.h>
+#include <prime/HullSpec.h>
+#include <prime/SpecService.h>
+#include <prime/Toast.h>
+#include <prime/UserProfile.h>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// SEH wrapper — catches access violations from bad IL2CPP pointers
+// ---------------------------------------------------------------------------
+template <typename Fn>
+static bool seh_call(Fn fn)
+{
+#if _WIN32
+  __try {
+    fn();
+    return true;
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return false;
+  }
+#else
+  fn();
+  return true;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Hull name key → human-readable name
+//   "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
+// ---------------------------------------------------------------------------
+static std::string parse_hull_key(const std::string& key)
+{
+  auto s = key;
+
+  if (s.size() > 5 && s.ends_with("_LIVE"))
+    s = s.substr(0, s.size() - 5);
+
+  if (s.starts_with("Hull_"))
+    s = s.substr(5);
+
+  for (auto& c : s)
+    if (c == '_') c = ' ';
+
+  if (s.size() >= 2 && s[0] == 'L' && std::isdigit(s[1])) {
+    auto space = s.find(' ');
+    auto lvl   = s.substr(1, space == std::string::npos ? std::string::npos : space - 1);
+    auto rest  = space == std::string::npos ? "" : s.substr(space);
+    s = "Lv." + lvl + rest;
+  }
+
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Resolve hull ID → display name via SpecService
+// ---------------------------------------------------------------------------
+static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
+{
+  if (hullId == 0) return "";
+
+  auto* specSvc = reinterpret_cast<SpecService*>(brh->get_SpecService());
+  if (!specSvc) return fmt::format("Hull#{}", hullId);
+
+  auto* hull = specSvc->GetHull(hullId);
+  if (!hull) return fmt::format("Hull#{}", hullId);
+
+  auto* nameStr = hull->Name;
+  auto nameKey  = nameStr ? to_string(nameStr) : std::string{};
+  if (!nameKey.empty()) return parse_hull_key(nameKey);
+
+  return fmt::format("Hull#{}", hullId);
+}
+
+// ---------------------------------------------------------------------------
+// Format "Name (Ship) vs Name (Ship)"
+// ---------------------------------------------------------------------------
+struct BattleSummaryData {
+  std::string playerName;
+  std::string enemyName;
+  std::string playerShip;
+  std::string enemyShip;
+
+  /** @brief Format the summary as "Player (Ship) vs Enemy (Ship)".
+   *  For NPCs (empty name), uses the ship hull name as the identifier. */
+  std::string format_body() const
+  {
+    auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
+      if (!name.empty() && !ship.empty()) return fmt::format("{} ({})", name, ship);
+      if (!name.empty()) return name;
+      if (!ship.empty()) return ship;
+      return "";
+    };
+
+    auto left  = format_side(playerName, playerShip);
+    auto right = format_side(enemyName, enemyShip);
+    if (left.empty() && right.empty()) return "";
+    if (left.empty()) return right;
+    if (right.empty()) return left;
+    return left + " vs " + right;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Extract player/enemy names + ship hulls from BattleResultHeader
+// ---------------------------------------------------------------------------
+static BattleSummaryData build_battle_data(Il2CppObject* data)
+{
+  BattleSummaryData result;
+  if (!data) return result;
+
+  auto* brh = reinterpret_cast<BattleResultHeader*>(data);
+
+  if (!seh_call([&] {
+        auto* p       = brh->get_PlayerUserProfile();
+        auto* profile = reinterpret_cast<UserProfile*>(p);
+        if (profile) {
+          auto* nameStr = profile->Name;
+          if (nameStr) result.playerName = to_string(nameStr);
+          // NPC profiles have empty names — leave blank, hull name used instead
+        }
+      }))
+    spdlog::warn("[Notify] SEH: get_PlayerUserProfile crashed");
+
+  if (!seh_call([&] {
+        auto* e       = brh->get_EnemyUserProfile();
+        auto* profile = reinterpret_cast<UserProfile*>(e);
+        if (profile) {
+          auto* nameStr = profile->Name;
+          if (nameStr) result.enemyName = to_string(nameStr);
+          // NPC profiles have empty names — leave blank, hull name used instead
+        }
+      }))
+    spdlog::warn("[Notify] SEH: get_EnemyUserProfile crashed");
+
+  if (!seh_call([&] {
+        auto hid          = brh->PlayerShipHullId;
+        result.playerShip = resolve_hull_name(brh, hid);
+      }))
+    spdlog::warn("[Notify] SEH: PlayerShipHullId crashed");
+
+  if (!seh_call([&] {
+        auto hid         = brh->EnemyShipHullId;
+        result.enemyShip = resolve_hull_name(brh, hid);
+      }))
+    spdlog::warn("[Notify] SEH: EnemyShipHullId crashed");
+
+  spdlog::info("[Notify] Battle: {} ({}) vs {} ({})", result.playerName, result.playerShip,
+               result.enemyName, result.enemyShip);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+std::string battle_notify_parse(Toast* toast)
+{
+  auto state = toast->get_State();
+
+  switch (state) {
+    case Victory:
+    case Defeat:
+    case PartialVictory:
+    case StationVictory:
+    case StationDefeat:
+    case StationBattle:
+    case IncomingAttack:
+    case FleetBattle:
+    case ArmadaBattleWon:
+    case ArmadaBattleLost:
+    case AssaultVictory:
+    case AssaultDefeat:
+      break;
+    default:
+      return {};
+  }
+
+  auto* data = toast->get_Data();
+  if (!data) return {};
+
+  auto bsd = build_battle_data(data);
+  return bsd.format_body();
+}

--- a/mods/src/patches/battle_notify_parser.h
+++ b/mods/src/patches/battle_notify_parser.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+struct Toast;
+
+// Attempt to build a detailed notification body from a battle toast's Data.
+// Returns empty string if the toast has no battle data or parsing fails.
+std::string battle_notify_parse(Toast* toast);

--- a/mods/src/patches/fleet_notifications.cc
+++ b/mods/src/patches/fleet_notifications.cc
@@ -1,0 +1,326 @@
+/**
+ * @file fleet_notifications.cc
+ * @brief Fleet notification state machine and message generation.
+ *
+ * This module tracks the last observed fleet-bar states and mining ETA hints,
+ * then emits OS notifications when meaningful fleet transitions occur.
+ */
+#include "patches/fleet_notifications.h"
+
+#include "config.h"
+#include "patches/notification_service.h"
+
+#include <prime/FleetPlayerData.h>
+#include <prime/SpecManager.h>
+
+#include <spdlog/spdlog.h>
+#include <str_utils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace {
+std::unordered_map<uint64_t, FleetState>  s_fleet_bar_states;
+std::unordered_map<uint64_t, std::string> s_fleet_bar_ship_names;
+std::unordered_map<uint64_t, std::string> s_fleet_bar_resource_names;
+std::unordered_map<uint64_t, float>       s_fleet_bar_cargo_fill_levels;
+std::unordered_map<uint64_t, int64_t>     s_mining_viewer_remaining_seconds;
+
+std::string fleet_bar_ship_name(FleetPlayerData* fleet)
+{
+  auto* hull = fleet ? fleet->Hull : nullptr;
+  auto  name = (hull && hull->Name) ? to_string(hull->Name) : std::string{"?"};
+
+  constexpr std::string_view live_suffix = "_LIVE";
+  if (name.size() >= live_suffix.size() &&
+      name.compare(name.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
+    name.erase(name.size() - live_suffix.size());
+  }
+
+  for (auto& ch : name) {
+    if (ch == '_') {
+      ch = ' ';
+    }
+  }
+
+  return name;
+}
+
+std::string fleet_bar_cached_ship_name(uint64_t fleetId)
+{
+  auto it = s_fleet_bar_ship_names.find(fleetId);
+  return it == s_fleet_bar_ship_names.end() ? std::string{} : it->second;
+}
+
+std::string fleet_bar_cached_resource_name(uint64_t fleetId)
+{
+  auto it = s_fleet_bar_resource_names.find(fleetId);
+  return it == s_fleet_bar_resource_names.end() ? std::string{} : it->second;
+}
+
+float fleet_bar_cached_cargo_fill_level(uint64_t fleetId)
+{
+  auto it = s_fleet_bar_cargo_fill_levels.find(fleetId);
+  return it == s_fleet_bar_cargo_fill_levels.end() ? -1.0f : it->second;
+}
+
+std::string normalize_resource_name(const std::string& name)
+{
+  if (name.empty()) {
+    return {};
+  }
+
+  auto normalized = name;
+  constexpr std::string_view live_suffix = "_LIVE";
+  if (normalized.size() >= live_suffix.size() &&
+      normalized.compare(normalized.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
+    normalized.erase(normalized.size() - live_suffix.size());
+  }
+
+  for (auto& ch : normalized) {
+    if (ch == '_') {
+      ch = ' ';
+    }
+  }
+
+  constexpr std::string_view resource_prefix = "Resource ";
+  if (normalized.size() >= resource_prefix.size() &&
+      normalized.compare(0, resource_prefix.size(), resource_prefix) == 0) {
+    normalized.erase(0, resource_prefix.size());
+  }
+
+  return normalized;
+}
+
+std::string fleet_bar_resource_name(FleetPlayerData* fleet)
+{
+  auto* miningData = fleet ? fleet->MiningData : nullptr;
+  if (!miningData) {
+    return {};
+  }
+
+  auto* specManager = SpecManager::Instance();
+  if (!specManager) {
+    return {};
+  }
+
+  auto* resourceSpec = specManager->GetResourceSpec(miningData->ResourceId);
+  auto* rawName      = resourceSpec ? resourceSpec->Name : nullptr;
+  auto  rawNameText  = rawName ? to_string(rawName) : std::string{};
+  return normalize_resource_name(rawNameText);
+}
+
+std::string format_duration_short(int64_t seconds)
+{
+  if (seconds <= 0) {
+    return {};
+  }
+
+  auto hourPart   = seconds / 3600;
+  auto minutePart = (seconds % 3600) / 60;
+  auto secondPart = seconds % 60;
+
+  std::ostringstream out;
+  if (hourPart > 0) {
+    out << hourPart << "h";
+    if (minutePart > 0) {
+      out << ' ' << minutePart << "m";
+    }
+    return out.str();
+  }
+
+  if (minutePart > 0) {
+    out << minutePart << "m";
+    if (secondPart > 0) {
+      out << ' ' << secondPart << "s";
+    }
+    return out.str();
+  }
+
+  out << secondPart << "s";
+  return out.str();
+}
+
+std::string format_cargo_fill_text(float fillLevel)
+{
+  if (!std::isfinite(fillLevel) || fillLevel < 0.0f) {
+    return {};
+  }
+
+  auto percent = static_cast<int>(std::lround(std::clamp(fillLevel, 0.0f, 1.0f) * 100.0f));
+  return "Current Cargo: " + std::to_string(percent) + "%";
+}
+
+std::string format_started_mining_title(const std::string& shipName, const std::string& resourceName)
+{
+  auto subject = shipName.empty() ? std::string{"Fleet"} : shipName;
+  auto title   = subject + " started mining";
+
+  if (!resourceName.empty()) {
+    title += " " + resourceName;
+  }
+
+  return title;
+}
+
+std::string format_started_mining_body(const std::string& etaText, const std::string& cargoText)
+{
+  std::string body;
+
+  if (!etaText.empty()) {
+    body += "ETA " + etaText;
+  }
+
+  if (!cargoText.empty()) {
+    if (!body.empty()) {
+      body += "\n";
+    }
+    body += cargoText;
+  }
+
+  return body;
+}
+
+std::string format_node_depleted_body(const std::string& shipName, const std::string& resourceName,
+                                      const std::string& cargoText)
+{
+  auto subject = (shipName.empty() || shipName == "?") ? std::string{"Fleet"} : shipName;
+  auto body    = subject + " depleted its";
+
+  if (!resourceName.empty()) {
+    body += " " + resourceName + " node.";
+  } else {
+    body += " node.";
+  }
+
+  if (!cargoText.empty()) {
+    body += " " + cargoText + ".";
+  }
+
+  return body;
+}
+
+int64_t duration_ticks_to_seconds(int64_t ticks)
+{
+  if (ticks < 0) {
+    return -1;
+  }
+
+  return static_cast<int64_t>(std::llround(static_cast<double>(ticks) / 10000000.0));
+}
+
+void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName,
+                                       FleetState oldState, FleetState newState,
+                                       const std::string& resourceName,
+                                       const std::string& cargoText)
+{
+  if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
+    if (!Config::Get().notifications.fleet_arrived_in_system) {
+      return;
+    }
+
+    auto body = "Your " + shipName + " has arrived in-system";
+    spdlog::debug("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
+    notification_show("Fleet Arrived", body.c_str());
+    return;
+  }
+
+  if (oldState != FleetState::Mining && newState == FleetState::Mining) {
+    if (!Config::Get().notifications.fleet_started_mining) {
+      return;
+    }
+
+    auto it      = s_mining_viewer_remaining_seconds.find(fleetId);
+    auto etaText = (it != s_mining_viewer_remaining_seconds.end()) ? format_duration_short(it->second) : std::string{};
+    auto title   = format_started_mining_title(shipName, resourceName);
+    auto body    = format_started_mining_body(etaText, cargoText);
+    s_mining_viewer_remaining_seconds.erase(fleetId);
+    notification_show(title.c_str(), body.c_str());
+    return;
+  }
+
+  if (oldState == FleetState::Mining && newState != FleetState::Mining) {
+    s_mining_viewer_remaining_seconds.erase(fleetId);
+  }
+
+  if (oldState != FleetState::Docked && newState == FleetState::Docked) {
+    if (!Config::Get().notifications.fleet_docked) {
+      return;
+    }
+
+    auto body = "Your " + shipName + " docked";
+    spdlog::debug("[FleetBar] DOCKED id={} ship='{}'", fleetId, shipName);
+    notification_show("Fleet Docked", body.c_str());
+  }
+}
+} // namespace
+
+void fleet_notifications_init()
+{
+  notification_init();
+}
+
+void fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet)
+{
+  if (!fleet) {
+    return;
+  }
+
+  auto fleetId        = fleet->Id;
+  auto currentState   = fleet->CurrentState;
+  auto shipName       = fleet_bar_ship_name(fleet);
+  auto resourceName   = fleet_bar_resource_name(fleet);
+  auto cargoFillLevel = fleet->CargoResourceFillLevel;
+  auto cargoText      = format_cargo_fill_text(cargoFillLevel);
+
+  auto it               = s_fleet_bar_states.find(fleetId);
+  auto previousState    = FleetState::Unknown;
+  auto hadPreviousState = false;
+  if (it != s_fleet_bar_states.end()) {
+    previousState    = it->second;
+    hadPreviousState = true;
+  }
+
+  s_fleet_bar_states[fleetId] = currentState;
+  s_fleet_bar_ship_names[fleetId] = shipName;
+  if (!resourceName.empty()) {
+    s_fleet_bar_resource_names[fleetId] = resourceName;
+  }
+  s_fleet_bar_cargo_fill_levels[fleetId] = cargoFillLevel;
+
+  if (hadPreviousState && previousState != currentState) {
+    maybe_notify_fleet_bar_transition(fleetId, shipName, previousState, currentState, resourceName, cargoText);
+  }
+}
+
+void fleet_notifications_observe_node_depleted(int64_t fleetId)
+{
+  if (!Config::Get().notifications.fleet_node_depleted) {
+    return;
+  }
+
+  auto shipName     = fleet_bar_cached_ship_name(static_cast<uint64_t>(fleetId));
+  auto resourceName = fleet_bar_cached_resource_name(static_cast<uint64_t>(fleetId));
+  auto cargoText    = format_cargo_fill_text(fleet_bar_cached_cargo_fill_level(static_cast<uint64_t>(fleetId)));
+
+  s_mining_viewer_remaining_seconds.erase(static_cast<uint64_t>(fleetId));
+
+  auto body = format_node_depleted_body(shipName, resourceName, cargoText);
+  notification_show("Node Depleted", body.c_str());
+}
+
+void fleet_notifications_observe_mining_timer(FleetPlayerData* selectedFleet, int64_t remainingTicks)
+{
+  if (!selectedFleet) {
+    return;
+  }
+
+  auto remainingSeconds = duration_ticks_to_seconds(remainingTicks);
+  if (remainingSeconds > 0) {
+    s_mining_viewer_remaining_seconds[selectedFleet->Id] = remainingSeconds;
+  }
+}

--- a/mods/src/patches/fleet_notifications.h
+++ b/mods/src/patches/fleet_notifications.h
@@ -1,0 +1,19 @@
+/**
+ * @file fleet_notifications.h
+ * @brief Fleet notification runtime logic independent from hook installation.
+ *
+ * The hook layer captures live fleet-bar and mining-viewer events, then hands
+ * those observations to this module. This file contains the notification state
+ * machine and message formatting, while the `parts/` layer stays limited to
+ * IL2CPP method discovery and hook injection.
+ */
+#pragma once
+
+#include <cstdint>
+
+struct FleetPlayerData;
+
+void fleet_notifications_init();
+void fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet);
+void fleet_notifications_observe_node_depleted(int64_t fleetId);
+void fleet_notifications_observe_mining_timer(FleetPlayerData* selectedFleet, int64_t remainingTicks);

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -22,6 +22,7 @@
 // IL2CPP method cache
 // ---------------------------------------------------------------------------
 static const MethodInfo* s_localize_ltc = nullptr;
+static bool              s_notification_initialized = false;
 
 // ---------------------------------------------------------------------------
 // Toast state → human-readable title
@@ -144,6 +145,10 @@ static std::string strip_unity_rich_text(const std::string& s)
 
 void notification_init()
 {
+  if (s_notification_initialized) {
+    return;
+  }
+
   // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
   // 2-parameter overload that takes an LTC and returns a localized string.
   auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
@@ -172,6 +177,15 @@ void notification_init()
   spdlog::info("[Notify] Windows notification service initialized");
 #else
   spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+
+  s_notification_initialized = true;
+}
+
+void notification_show(const char* title, const char* body)
+{
+#if _WIN32
+  show_system_notification(title, body);
 #endif
 }
 

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,0 +1,208 @@
+#include "patches/notification_service.h"
+#include "patches/battle_notify_parser.h"
+
+#include "config.h"
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <prime/LanguageManager.h>
+#include <prime/Toast.h>
+
+#include <spdlog/spdlog.h>
+
+#include <string>
+
+#if _WIN32
+#include <windows.h>
+#include <winrt/Windows.Data.Xml.Dom.h>
+#include <winrt/Windows.UI.Notifications.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// IL2CPP method cache
+// ---------------------------------------------------------------------------
+static const MethodInfo* s_localize_ltc = nullptr;
+
+// ---------------------------------------------------------------------------
+// Toast state → human-readable title
+// ---------------------------------------------------------------------------
+static const char* toast_state_title(int state)
+{
+  switch (state) {
+    case Victory:                   return "Victory!";
+    case Defeat:                    return "Defeat";
+    case PartialVictory:            return "Partial Victory";
+    case StationVictory:            return "Station Victory!";
+    case StationDefeat:             return "Station Defeat";
+    case StationBattle:             return "Station Under Attack!";
+    case IncomingAttack:            return "Incoming Attack!";
+    case IncomingAttackFaction:     return "Incoming Faction Attack!";
+    case FleetBattle:               return "Fleet Battle";
+    case ArmadaBattleWon:           return "Armada Victory!";
+    case ArmadaBattleLost:          return "Armada Defeated";
+    case ArmadaCreated:             return "Armada Created";
+    case ArmadaCanceled:            return "Armada Canceled";
+    case ArmadaIncomingAttack:      return "Armada Under Attack!";
+    case AssaultVictory:            return "Assault Victory!";
+    case AssaultDefeat:             return "Assault Defeat";
+    case Tournament:                return "Event Progress";
+    case ChainedEventScored:        return "Event Progress";
+    case Achievement:               return "Achievement";
+    case ChallengeComplete:         return "Challenge Complete";
+    case ChallengeFailed:           return "Challenge Failed";
+    case TakeoverVictory:           return "Takeover Victory!";
+    case TakeoverDefeat:            return "Takeover Defeat";
+    case TreasuryProgress:          return "Treasury Progress";
+    case TreasuryFull:              return "Treasury Full";
+    case WarchestProgress:          return "Warchest Progress";
+    case WarchestFull:              return "Warchest Full";
+    case FactionLevelUp:            return "Faction Level Up";
+    case FactionLevelDown:          return "Faction Level Down";
+    case FactionDiscovered:         return "Faction Discovered";
+    case FactionWarning:            return "Faction Warning";
+    case DiplomacyUpdated:          return "Diplomacy Updated";
+    case StrikeHit:                 return "Strike Hit";
+    case StrikeDefeat:              return "Strike Defeat";
+    case SurgeWarmUpEnded:          return "Surge Started";
+    case SurgeHostileGroupDefeated: return "Surge Hostiles Defeated";
+    case SurgeTimeLeft:             return "Surge Time Warning";
+    case ArenaTimeLeft:             return "Arena Time Warning";
+    case FleetPresetApplied:        return "Fleet Preset Applied";
+    default:                        return nullptr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform notification delivery
+// ---------------------------------------------------------------------------
+#if _WIN32
+static void show_system_notification(const char* title, const char* body)
+{
+  try {
+    using namespace winrt::Windows::UI::Notifications;
+    using namespace winrt::Windows::Data::Xml::Dom;
+
+    auto xml   = ToastNotificationManager::GetTemplateContent(ToastTemplateType::ToastText02);
+    auto nodes = xml.GetElementsByTagName(L"text");
+    nodes.Item(0).InnerText(winrt::to_hstring(title));
+    nodes.Item(1).InnerText(winrt::to_hstring(body));
+
+    auto notification = ToastNotification(xml);
+    auto notifier     = ToastNotificationManager::CreateToastNotifier(L"Star Trek Fleet Command");
+    notifier.Show(notification);
+  } catch (const winrt::hresult_error& e) {
+    spdlog::warn("[Notify] WinRT notification failed: {}", winrt::to_string(e.message()));
+  } catch (...) {
+    spdlog::warn("[Notify] WinRT notification failed (unknown error)");
+  }
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// Resolve basic localized text from a Toast's TextLocaleTextContext
+// ---------------------------------------------------------------------------
+static std::string resolve_toast_text(Toast* toast)
+{
+  if (!s_localize_ltc) return {};
+
+  auto* ltc = toast->get_TextLocaleTextContext();
+  if (!ltc) return {};
+
+  auto* langMgr = LanguageManager::Instance();
+  if (!langMgr) return {};
+
+  Il2CppString*  resolved = nullptr;
+  void*          params[2] = { &resolved, ltc };
+  Il2CppException* exc = nullptr;
+  il2cpp_runtime_invoke(s_localize_ltc, langMgr, params, &exc);
+
+  if (exc || !resolved) return {};
+  return to_string(resolved);
+}
+
+// ---------------------------------------------------------------------------
+// Strip Unity rich text tags (e.g. <color=#FF0000>, <b>, </size>)
+// ---------------------------------------------------------------------------
+static std::string strip_unity_rich_text(const std::string& s)
+{
+  std::string result;
+  result.reserve(s.size());
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '<') {
+      auto end = s.find('>', i);
+      if (end != std::string::npos) { i = end + 1; continue; }
+    }
+    result += s[i++];
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void notification_init()
+{
+  // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
+  // 2-parameter overload that takes an LTC and returns a localized string.
+  auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
+  if (lm_helper.isValidHelper()) {
+    auto* cls = lm_helper.get_cls();
+    if (cls) {
+      void* iter = nullptr;
+      while (auto* method = il2cpp_class_get_methods(cls, &iter)) {
+        auto name = std::string_view(il2cpp_method_get_name(method));
+        auto pc   = il2cpp_method_get_param_count(method);
+        if (name == "Localize" && pc == 2) {
+          s_localize_ltc = method;
+          spdlog::info("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
+          break;
+        }
+      }
+    }
+  }
+
+  if (!s_localize_ltc) {
+    spdlog::warn("[Notify] Could not resolve LanguageManager::Localize — notifications will show titles only");
+  }
+
+#if _WIN32
+  try { winrt::init_apartment(); } catch (...) {}
+  spdlog::info("[Notify] Windows notification service initialized");
+#else
+  spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+}
+
+void notification_handle_toast(Toast* toast)
+{
+#if !_WIN32
+  return; // No notification delivery on non-Windows platforms yet
+#else
+  auto state = toast->get_State();
+
+  // Check if this toast type is in the user's notify list
+  const auto& notify_types = Config::Get().notify_banner_types;
+  if (std::ranges::find(notify_types, state) == notify_types.end()) {
+    return;
+  }
+
+  auto* title = toast_state_title(state);
+  if (!title) {
+    spdlog::debug("[Notify] No title mapping for toast state {}, skipping", state);
+    return;
+  }
+
+  auto body = battle_notify_parse(toast);
+  if (body.empty()) {
+    body = strip_unity_rich_text(resolve_toast_text(toast));
+  }
+  if (body.empty()) {
+    body = "(no details available)";
+  }
+
+  spdlog::info("[Notify] {} — {}", title, body);
+  show_system_notification(title, body.c_str());
+#endif
+}

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -184,6 +184,10 @@ void notification_init()
 
 void notification_show(const char* title, const char* body)
 {
+  if (!Config::Get().notifications.enabled) {
+    return;
+  }
+
 #if _WIN32
   show_system_notification(title, body);
 #endif

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -194,11 +194,14 @@ void notification_handle_toast(Toast* toast)
 #if !_WIN32
   return; // No notification delivery on non-Windows platforms yet
 #else
+  const auto& notifications = Config::Get().notifications;
+  if (!notifications.enabled) {
+    return;
+  }
+
   auto state = toast->get_State();
 
-  // Check if this toast type is in the user's notify list
-  const auto& notify_types = Config::Get().notify_banner_types;
-  if (std::ranges::find(notify_types, state) == notify_types.end()) {
+  if (!notifications.EnabledForToastState(state)) {
     return;
   }
 

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -1,0 +1,10 @@
+#pragma once
+
+struct Toast;
+
+// Initialize the notification service (resolve IL2CPP methods, init platform).
+// Call once during InstallToastBannerHooks().
+void notification_init();
+
+// Called from toast hooks — checks config, formats, and delivers notification.
+void notification_handle_toast(Toast* toast);

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -8,3 +8,13 @@ void notification_init();
 
 // Called from toast hooks — checks config, formats, and delivers notification.
 void notification_handle_toast(Toast* toast);
+
+/**
+ * @brief Send an arbitrary OS-native notification with the given title and body.
+ *
+ * Requires notification_init() to have been called first. No-op on non-Windows.
+ *
+ * @param title Notification title text.
+ * @param body  Notification body text.
+ */
+void notification_show(const char* title, const char* body);

--- a/mods/src/patches/parts/disable_banners.cc
+++ b/mods/src/patches/parts/disable_banners.cc
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "errormsg.h"
+#include "patches/notification_service.h"
 
 #include <il2cpp/il2cpp_helper.h>
 #include <prime/Toast.h>
@@ -11,6 +12,8 @@ struct ToastObserver {
 
 void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast *toast)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -21,6 +24,8 @@ void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast 
 
 void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_this, Toast *toast, uintptr_t cmpAction)
 {
+  notification_handle_toast(toast);
+
   if (std::ranges::find(Config::Get().disabled_banner_types, toast->get_State())
       != Config::Get().disabled_banner_types.end()) {
     return;
@@ -31,6 +36,8 @@ void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_thi
 
 void InstallToastBannerHooks()
 {
+  notification_init();
+
   if (auto helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "ToastObserver");
       !helper.isValidHelper()) {
     ErrorMsg::MissingHelper("HUD", "ToastObserver");

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -22,25 +22,6 @@
 
 static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
 
-static const char* fleet_bar_state_str(FleetState state)
-{
-  switch (state) {
-    case FleetState::Unknown:      return "Unknown";
-    case FleetState::IdleInSpace:  return "IdleInSpace";
-    case FleetState::Docked:       return "Docked";
-    case FleetState::Mining:       return "Mining";
-    case FleetState::Destroyed:    return "Destroyed";
-    case FleetState::TieringUp:    return "TieringUp";
-    case FleetState::Repairing:    return "Repairing";
-    case FleetState::Battling:     return "Battling";
-    case FleetState::WarpCharging: return "WarpCharging";
-    case FleetState::Warping:      return "Warping";
-    case FleetState::Impulsing:    return "Impulsing";
-    case FleetState::Capturing:    return "Capturing";
-    default:                       return "Composite";
-  }
-}
-
 static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
 {
   auto* hull = fleet ? fleet->Hull : nullptr;
@@ -86,10 +67,6 @@ static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::strin
     spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
     return;
   }
-
-  if (oldState == FleetState::Warping && newState == FleetState::Docked) {
-    spdlog::info("[FleetBar] DOCKED_AFTER_WARP id={} ship='{}'", fleetId, shipName);
-  }
 }
 
 static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
@@ -101,14 +78,7 @@ static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
     auto shipName     = fleet_bar_ship_name(fleet);
 
     auto it = s_fleet_bar_states.find(fleetId);
-    if (it == s_fleet_bar_states.end()) {
-      spdlog::info("[FleetBar] SetWidgetData snapshot id={} ship='{}' state={}({})",
-                   fleetId, shipName, fleet_bar_state_str(currentState), (int)currentState);
-    } else if (it->second != currentState) {
-      spdlog::info("[FleetBar] SetWidgetData state id={} ship='{}' {}({}) -> {}({})",
-                   fleetId, shipName,
-                   fleet_bar_state_str(it->second), (int)it->second,
-                   fleet_bar_state_str(currentState), (int)currentState);
+    if (it != s_fleet_bar_states.end() && it->second != currentState) {
       maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
     }
 

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -1,0 +1,138 @@
+/**
+ * @file fleet_arrival.cc
+ * @brief Fleet arrival detection driven by the bottom fleet bar state widgets.
+ *
+ * Hooks FleetStateWidget::SetWidgetData and watches FleetPlayerData state
+ * transitions. The most useful arrival signal is Warping -> Impulsing, which
+ * means the ship has dropped out of warp and entered the destination system.
+ */
+#include "errormsg.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <spud/detour.h>
+
+#include <patches/notification_service.h>
+#include <prime/FleetPlayerData.h>
+
+#include <spdlog/spdlog.h>
+#include <str_utils.h>
+
+#include <string_view>
+#include <unordered_map>
+
+static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
+
+static const char* fleet_bar_state_str(FleetState state)
+{
+  switch (state) {
+    case FleetState::Unknown:      return "Unknown";
+    case FleetState::IdleInSpace:  return "IdleInSpace";
+    case FleetState::Docked:       return "Docked";
+    case FleetState::Mining:       return "Mining";
+    case FleetState::Destroyed:    return "Destroyed";
+    case FleetState::TieringUp:    return "TieringUp";
+    case FleetState::Repairing:    return "Repairing";
+    case FleetState::Battling:     return "Battling";
+    case FleetState::WarpCharging: return "WarpCharging";
+    case FleetState::Warping:      return "Warping";
+    case FleetState::Impulsing:    return "Impulsing";
+    case FleetState::Capturing:    return "Capturing";
+    default:                       return "Composite";
+  }
+}
+
+static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
+{
+  auto* hull = fleet ? fleet->Hull : nullptr;
+  auto  name = (hull && hull->Name) ? to_string(hull->Name) : std::string{"?"};
+
+  constexpr std::string_view live_suffix = "_LIVE";
+  if (name.size() >= live_suffix.size() &&
+      name.compare(name.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
+    name.erase(name.size() - live_suffix.size());
+  }
+
+  for (auto& ch : name) {
+    if (ch == '_') {
+      ch = ' ';
+    }
+  }
+
+  return name;
+}
+
+static FleetPlayerData* fleet_bar_widget_context(void* self)
+{
+  if (!self) {
+    return nullptr;
+  }
+
+  auto helper      = IL2CppClassHelper{((Il2CppObject*)self)->klass};
+  auto get_context = helper.GetMethod<FleetPlayerData*(void*)>("get_Context", 0);
+  return get_context ? get_context(self) : nullptr;
+}
+
+static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName,
+                                              FleetState oldState, FleetState newState)
+{
+  if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
+    auto body = "Your " + shipName + " has arrived in-system";
+    spdlog::info("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
+    notification_show("Fleet Arrived", body.c_str());
+    return;
+  }
+
+  if (oldState == FleetState::Impulsing && newState == FleetState::IdleInSpace) {
+    spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
+    return;
+  }
+
+  if (oldState == FleetState::Warping && newState == FleetState::Docked) {
+    spdlog::info("[FleetBar] DOCKED_AFTER_WARP id={} ship='{}'", fleetId, shipName);
+  }
+}
+
+static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
+{
+  auto* fleet = fleet_bar_widget_context(self);
+  if (fleet) {
+    auto fleetId      = fleet->Id;
+    auto currentState = fleet->CurrentState;
+    auto shipName     = fleet_bar_ship_name(fleet);
+
+    auto it = s_fleet_bar_states.find(fleetId);
+    if (it == s_fleet_bar_states.end()) {
+      spdlog::info("[FleetBar] SetWidgetData snapshot id={} ship='{}' state={}({})",
+                   fleetId, shipName, fleet_bar_state_str(currentState), (int)currentState);
+    } else if (it->second != currentState) {
+      spdlog::info("[FleetBar] SetWidgetData state id={} ship='{}' {}({}) -> {}({})",
+                   fleetId, shipName,
+                   fleet_bar_state_str(it->second), (int)it->second,
+                   fleet_bar_state_str(currentState), (int)currentState);
+      maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
+    }
+
+    s_fleet_bar_states[fleetId] = currentState;
+  }
+
+  original(self);
+}
+
+void InstallFleetArrivalHooks()
+{
+  notification_init();
+
+  auto fleet_state_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget");
+  if (!fleet_state_widget.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Prime.HUD", "FleetStateWidget");
+    return;
+  }
+
+  auto set_widget_data = fleet_state_widget.GetMethod("SetWidgetData");
+  if (set_widget_data == nullptr) {
+    ErrorMsg::MissingMethod("FleetStateWidget", "SetWidgetData");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(set_widget_data, FleetStateWidget_SetWidgetData_Hook);
+}

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -8,39 +8,15 @@
  */
 #include "errormsg.h"
 
+#include <patches/fleet_notifications.h>
+
 #include <il2cpp/il2cpp_helper.h>
+#include <prime/MiningObjectViewerWidget.h>
 #include <spud/detour.h>
 
-#include <patches/notification_service.h>
 #include <prime/FleetPlayerData.h>
 
 #include <spdlog/spdlog.h>
-#include <str_utils.h>
-
-#include <string_view>
-#include <unordered_map>
-
-static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
-
-static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
-{
-  auto* hull = fleet ? fleet->Hull : nullptr;
-  auto  name = (hull && hull->Name) ? to_string(hull->Name) : std::string{"?"};
-
-  constexpr std::string_view live_suffix = "_LIVE";
-  if (name.size() >= live_suffix.size() &&
-      name.compare(name.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
-    name.erase(name.size() - live_suffix.size());
-  }
-
-  for (auto& ch : name) {
-    if (ch == '_') {
-      ch = ' ';
-    }
-  }
-
-  return name;
-}
 
 static FleetPlayerData* fleet_bar_widget_context(void* self)
 {
@@ -53,44 +29,33 @@ static FleetPlayerData* fleet_bar_widget_context(void* self)
   return get_context ? get_context(self) : nullptr;
 }
 
-static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName,
-                                              FleetState oldState, FleetState newState)
-{
-  if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
-    auto body = "Your " + shipName + " has arrived in-system";
-    spdlog::info("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
-    notification_show("Fleet Arrived", body.c_str());
-    return;
-  }
-
-  if (oldState == FleetState::Impulsing && newState == FleetState::IdleInSpace) {
-    spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
-    return;
-  }
-}
-
 static void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
 {
   auto* fleet = fleet_bar_widget_context(self);
-  if (fleet) {
-    auto fleetId      = fleet->Id;
-    auto currentState = fleet->CurrentState;
-    auto shipName     = fleet_bar_ship_name(fleet);
-
-    auto it = s_fleet_bar_states.find(fleetId);
-    if (it != s_fleet_bar_states.end() && it->second != currentState) {
-      maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
-    }
-
-    s_fleet_bar_states[fleetId] = currentState;
-  }
+  fleet_notifications_observe_fleet_bar(fleet);
 
   original(self);
 }
 
+static void ToastFleetObserver_HandleMiningDepleted_Hook(auto original, void* self, int64_t fleetId)
+{
+  original(self, fleetId);
+  fleet_notifications_observe_node_depleted(fleetId);
+}
+
+static void MiningObjectViewerWidget_UpdateTimerWidget_Hook(auto original, MiningObjectViewerWidget* self,
+                                                            FleetPlayerData* selectedFleet)
+{
+  original(self, selectedFleet);
+
+  auto* timerContext  = self ? self->_miningTimerWidgetContext : nullptr;
+  auto remainingTicks = timerContext ? timerContext->RemainingTime.Ticks : -1;
+  fleet_notifications_observe_mining_timer(selectedFleet, remainingTicks);
+}
+
 void InstallFleetArrivalHooks()
 {
-  notification_init();
+  fleet_notifications_init();
 
   auto fleet_state_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget");
   if (!fleet_state_widget.isValidHelper()) {
@@ -105,4 +70,33 @@ void InstallFleetArrivalHooks()
   }
 
   SPUD_STATIC_DETOUR(set_widget_data, FleetStateWidget_SetWidgetData_Hook);
+
+  auto toast_fleet_observer = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "ToastFleetObserver");
+  if (!toast_fleet_observer.isValidHelper()) {
+    spdlog::warn("[Fleet] ToastFleetObserver helper not found; node depleted notifications disabled");
+    return;
+  }
+
+  auto handle_mining_depleted = toast_fleet_observer.GetMethod("HandleMiningDepleted");
+  if (handle_mining_depleted == nullptr) {
+    spdlog::warn("[Fleet] ToastFleetObserver.HandleMiningDepleted not found; node depleted notifications disabled");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(handle_mining_depleted, ToastFleetObserver_HandleMiningDepleted_Hook);
+
+  auto mining_object_viewer = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.ObjectViewer", "MiningObjectViewerWidget");
+  if (!mining_object_viewer.isValidHelper()) {
+    spdlog::warn("[MiningViewer] MiningObjectViewerWidget helper not found; mining ETA disabled");
+    return;
+  }
+
+  auto update_timer_widget = mining_object_viewer.GetMethod<void(MiningObjectViewerWidget*, FleetPlayerData*)>(
+      "UpdateTimerWidget", 1);
+  if (update_timer_widget == nullptr) {
+    spdlog::warn("[MiningViewer] MiningObjectViewerWidget.UpdateTimerWidget not found; mining ETA disabled");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(update_timer_widget, MiningObjectViewerWidget_UpdateTimerWidget_Hook);
 }

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -36,6 +36,7 @@ void InstallResolutionListFix();
 void InstallTempCrashFixes();
 void InstallSyncPatches();
 void InstallObjectTrackers();
+void InstallFleetArrivalHooks();
 void InstallLoadingScreenBgHooks();
 
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
@@ -119,6 +120,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"ResolutionListFix", {InstallResolutionListFix, &cfg.installResolutionListFix}},
       {"SyncPatches", {InstallSyncPatches, &cfg.installSyncPatches}},
       {"ObjectTracker", {InstallObjectTrackers, &cfg.installObjectTracker}},
+      {"FleetArrival", {InstallFleetArrivalHooks, &cfg.installFleetArrivalHooks}},
       {"LoadingScreenBgHooks", {InstallLoadingScreenBgHooks, &cfg.installLoadingScreenBgHooks}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);

--- a/mods/src/prime/BattleResultHeader.h
+++ b/mods/src/prime/BattleResultHeader.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+enum class BattleType {
+  Fleet                          = 0,
+  Base                           = 1,
+  PassiveMarauder                = 2,
+  NpcInstantiated                = 3,
+  DockingPoint                   = 4,
+  ActiveMarauder_MarauderInit    = 5,
+  ActiveMarauder_PlayerInit      = 6,
+  ArmadaBase                     = 7,
+  ArmadaMarauder                 = 8,
+  PveDockingPoint                = 9,
+  ArmadaAsb                      = 10,
+  ArmadaMta                      = 11,
+  Hazard                         = 12,
+  PveCuttingBeam                 = 13,
+  PvpCuttingBeam                 = 14,
+  PveChainShot                   = 15,
+  PvpChainShot                   = 16
+};
+
+enum class BattleResultType {
+  Defeat         = 0,
+  Victory        = 1,
+  PartialVictory = 2
+};
+
+enum class FleetDataType {
+  DeployedFleet = 0,
+  Starbase      = 1,
+  Armada        = 2
+};
+
+struct BattleResultHeader {
+public:
+  __declspec(property(get = __get_PlayerShipHullId)) long PlayerShipHullId;
+  __declspec(property(get = __get_EnemyShipHullId)) long EnemyShipHullId;
+
+  Il2CppObject* get_PlayerUserProfile()
+  {
+    static auto prop = get_class_helper().GetProperty("PlayerUserProfile");
+    return prop.GetRaw<Il2CppObject>(this);
+  }
+
+  Il2CppObject* get_EnemyUserProfile()
+  {
+    static auto prop = get_class_helper().GetProperty("EnemyUserProfile");
+    return prop.GetRaw<Il2CppObject>(this);
+  }
+
+  Il2CppObject* get_SpecService()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x18);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "BattleResultHeader");
+    return class_helper;
+  }
+
+public:
+  long __get_PlayerShipHullId()
+  {
+    static auto prop = get_class_helper().GetProperty("PlayerShipHullId");
+    return *prop.Get<long>(this);
+  }
+
+  long __get_EnemyShipHullId()
+  {
+    static auto prop = get_class_helper().GetProperty("EnemyShipHullId");
+    return *prop.Get<long>(this);
+  }
+};

--- a/mods/src/prime/FleetPlayerData.h
+++ b/mods/src/prime/FleetPlayerData.h
@@ -2,6 +2,7 @@
 
 #include "BattleTargetData.h"
 #include "HullSpec.h"
+#include "MiningSlot.h"
 #include "RecallRequirement.h"
 #include "CanRepairRequirement.h"
 
@@ -36,6 +37,8 @@ public:
   __declspec(property(get = __get_PreviousState)) FleetState PreviousState;
   __declspec(property(get = __get_Id)) uint64_t Id;
   __declspec(property(get = __get_Hull)) HullSpec* Hull;
+  __declspec(property(get = __get_MiningData)) MiningSlot* MiningData;
+  __declspec(property(get = __get_CargoResourceFillLevel)) float CargoResourceFillLevel;
   __declspec(property(get = __get_Address)) void* Address;
   __declspec(property(get = __get_RecallRequirements)) RecallRequirement* RecallRequirements;
   __declspec(property(get = __get_CanRepairRequirement)) CanRepairRequirement* CanRepairRequirements;
@@ -54,6 +57,20 @@ public:
     static auto field = get_class_helper().GetProperty("Hull");
     return field.GetRaw<HullSpec>(this);
   }
+
+  MiningSlot* __get_MiningData()
+  {
+    static auto field = get_class_helper().GetProperty("MiningData");
+    return field.GetRaw<MiningSlot>(this);
+  }
+
+  float __get_CargoResourceFillLevel()
+  {
+    static auto field = get_class_helper().GetProperty("CargoResourceFillLevel");
+    auto* value = field.Get<float>(this);
+    return value ? *value : -1.0f;
+  }
+
   void* __get_Address()
   {
     static auto field = get_class_helper().GetProperty("Address");

--- a/mods/src/prime/HullSpec.h
+++ b/mods/src/prime/HullSpec.h
@@ -15,6 +15,7 @@ enum class HullType {
 struct HullSpec {
 public:
   __declspec(property(get = __get_Id)) long Id;
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
   __declspec(property(get = __get_Type)) HullType Type;
 
 private:
@@ -32,9 +33,15 @@ public:
     return *(long*)((char*)this + field);
   }
 
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+
   HullType __get_Type()
   {
-    static auto field = get_class_helper().GetProperty("Type");
-    return *field.Get<HullType>(this);
+    static auto prop = get_class_helper().GetProperty("Type");
+    return *prop.Get<HullType>(this);
   }
 };

--- a/mods/src/prime/MiningObjectViewerWidget.h
+++ b/mods/src/prime/MiningObjectViewerWidget.h
@@ -7,6 +7,7 @@
 #include "NavigationInteractionUIContext.h"
 #include "ObjectViewerBaseWidget.h"
 #include "ScanEngageButtonsWidget.h"
+#include "TimerDataContext.h"
 
 enum OccupiedState // TypeDefIndex: 12900
 {
@@ -19,6 +20,7 @@ struct MiningObjectViewerWidget : public ObjectViewerBaseWidget<MiningObjectView
 public:
   __declspec(property(get = __get__occupiedState)) OccupiedState _occupiedState;
   __declspec(property(get = __get__scanEngageButtonsWidget)) ScanEngageButtonsWidget* _scanEngageButtonsWidget;
+  __declspec(property(get = __get__miningTimerWidgetContext)) TimerDataContext* _miningTimerWidgetContext;
 
   void MineClicked()
   {
@@ -47,5 +49,11 @@ public:
   {
     static auto field = get_class_helper().GetField("_scanEngageButtonsWidget").offset();
     return *(ScanEngageButtonsWidget**)((char*)this + field);
+  }
+
+  TimerDataContext* __get__miningTimerWidgetContext()
+  {
+    static auto field = get_class_helper().GetField("_miningTimerWidgetContext").offset();
+    return *(TimerDataContext**)((char*)this + field);
   }
 };

--- a/mods/src/prime/MiningSlot.h
+++ b/mods/src/prime/MiningSlot.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "TimeSpan.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct MiningNodeParams {
+public:
+  __declspec(property(get = __get_Amount)) int64_t Amount;
+  __declspec(property(get = __get_ResourceID)) int64_t ResourceID;
+  __declspec(property(get = __get_Rate)) int64_t Rate;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "MiningNodeParams");
+    return class_helper;
+  }
+
+public:
+  int64_t __get_Amount()
+  {
+    static auto field = get_class_helper().GetProperty("Amount");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  int64_t __get_ResourceID()
+  {
+    static auto field = get_class_helper().GetProperty("ResourceID");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  int64_t __get_Rate()
+  {
+    static auto field = get_class_helper().GetProperty("Rate");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+};
+
+struct MiningSlot {
+public:
+  __declspec(property(get = __get_PointData)) MiningNodeParams* PointData;
+  __declspec(property(get = __get_ResourceId)) int64_t ResourceId;
+  __declspec(property(get = __get_PerHourRate)) int64_t PerHourRate;
+  __declspec(property(get = __get_RemainingTime)) TimeSpan RemainingTime;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "MiningSlot");
+    return class_helper;
+  }
+
+public:
+  MiningNodeParams* __get_PointData()
+  {
+    static auto field = get_class_helper().GetProperty("PointData");
+    return field.GetRaw<MiningNodeParams>(this);
+  }
+
+  int64_t __get_ResourceId()
+  {
+    static auto field = get_class_helper().GetProperty("ResourceId");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  int64_t __get_PerHourRate()
+  {
+    static auto field = get_class_helper().GetProperty("PerHourRate");
+    auto* value = field.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  TimeSpan __get_RemainingTime()
+  {
+    static auto field = get_class_helper().GetProperty("RemainingTime");
+    auto* value = field.Get<TimeSpan>(this);
+    return value ? *value : TimeSpan{};
+  }
+};

--- a/mods/src/prime/ResourceSpec.h
+++ b/mods/src/prime/ResourceSpec.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct ResourceSpec {
+public:
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "ResourceSpec");
+    return class_helper;
+  }
+
+public:
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetProperty("Name");
+    return field.GetRaw<Il2CppString>(this);
+  }
+};

--- a/mods/src/prime/SpecManager.h
+++ b/mods/src/prime/SpecManager.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "errormsg.h"
+#include "MonoSingleton.h"
+#include "ResourceSpec.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct SpecManager : MonoSingleton<SpecManager> {
+  friend struct MonoSingleton<SpecManager>;
+
+public:
+  ResourceSpec* GetResourceSpec(int64_t id)
+  {
+    static auto method = get_class_helper().GetMethod<ResourceSpec*(SpecManager*, int64_t)>("GetResourceSpec");
+    static auto warn   = true;
+
+    if (method) {
+      return method(this, id);
+    }
+
+    if (warn) {
+      warn = false;
+      ErrorMsg::MissingMethod("SpecManager", "GetResourceSpec");
+    }
+
+    return nullptr;
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Navigation.Managers", "SpecManager");
+    return class_helper;
+  }
+};

--- a/mods/src/prime/SpecService.h
+++ b/mods/src/prime/SpecService.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+#include "HullSpec.h"
+
+struct SpecService {
+public:
+  HullSpec* GetHull(long hullId)
+  {
+    static auto method =
+        get_class_helper().GetMethod<HullSpec*(SpecService*, long)>("GetHull");
+    return method(this, hullId);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Services", "SpecService");
+    return class_helper;
+  }
+};

--- a/mods/src/prime/TimeSpan.h
+++ b/mods/src/prime/TimeSpan.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+struct TimeSpan {
+public:
+  __declspec(property(get = __get_Ticks)) int64_t Ticks;
+
+  int64_t __get_Ticks() const
+  {
+    return ticks;
+  }
+
+  double TotalSeconds() const
+  {
+    return static_cast<double>(ticks) / 10000000.0;
+  }
+
+private:
+  int64_t ticks = 0;
+};

--- a/mods/src/prime/TimerDataContext.h
+++ b/mods/src/prime/TimerDataContext.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "TimeSpan.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct TimerDataContext {
+public:
+  __declspec(property(get = __get_RemainingTime)) TimeSpan RemainingTime;
+  __declspec(property(get = __get_TimerTypeValue)) int TimerTypeValue;
+  __declspec(property(get = __get_TimerStateValue)) int TimerStateValue;
+  __declspec(property(get = __get_ShowTimerLabel)) bool ShowTimerLabel;
+
+  TimeSpan __get_RemainingTime()
+  {
+    auto helper = IL2CppClassHelper{((Il2CppObject*)this)->klass};
+    auto field  = helper.GetProperty("RemainingTime");
+    auto* value = field.Get<TimeSpan>(this);
+    return value ? *value : TimeSpan{};
+  }
+
+  int __get_TimerTypeValue()
+  {
+    auto helper = IL2CppClassHelper{((Il2CppObject*)this)->klass};
+    auto field  = helper.GetProperty("TimerType");
+    auto* value = field.Get<int>(this);
+    return value ? *value : -1;
+  }
+
+  int __get_TimerStateValue()
+  {
+    auto helper = IL2CppClassHelper{((Il2CppObject*)this)->klass};
+    auto field  = helper.GetProperty("TimerState");
+    auto* value = field.Get<int>(this);
+    return value ? *value : -1;
+  }
+
+  bool __get_ShowTimerLabel()
+  {
+    auto helper = IL2CppClassHelper{((Il2CppObject*)this)->klass};
+    auto field  = helper.GetProperty("ShowTimerLabel");
+    auto* value = field.Get<bool>(this);
+    return value ? *value : false;
+  }
+};

--- a/mods/src/prime/Toast.h
+++ b/mods/src/prime/Toast.h
@@ -50,6 +50,16 @@ enum ToastState {
 
 struct Toast {
 public:
+  void* get_TextLocaleTextContext()
+  {
+    return *reinterpret_cast<void**>(reinterpret_cast<char*>(this) + 0x20);
+  }
+
+  Il2CppObject* get_Data()
+  {
+    return *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(this) + 0x38);
+  }
+
   int get_State()
   {
     static auto prop = get_class_helper().GetProperty("State");

--- a/mods/src/prime/UserProfile.h
+++ b/mods/src/prime/UserProfile.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct UserProfile {
+public:
+  __declspec(property(get = __get_LocaId)) long LocaId;
+  __declspec(property(get = __get_Name)) Il2CppString* Name;
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "UserProfile");
+    return class_helper;
+  }
+
+public:
+  long __get_LocaId()
+  {
+    static auto field = get_class_helper().GetField("_locaId").offset();
+    return *(long*)((char*)this + field);
+  }
+
+  Il2CppString* __get_Name()
+  {
+    static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+};


### PR DESCRIPTION
## Reviewer Quick Path

This is the `138B` draft. The upstream GitHub diff is cumulative because the PR targets `main`; for the incremental review, use this source-branch compare link first:

https://github.com/Guffawaffle/stfc-mod/compare/restack/pr138a-notification-foundation...restack/pr138b-fleet-alerts-policy

Focus on the commits on top of `#170`.

## Summary

- add a real `NotificationConfig` model and `[notifications]` config surface with legacy `[ui].notify_banner_types` migration
- gate toast delivery through the notification policy instead of the old notify allowlist vector
- add the `fleet_notifications` runtime for fleet arrival, node depleted, mining, and docked notification decisions
- keep `fleet_arrival` focused on hook and signal capture and port the minimal prime wrappers the fleet runtime needs

## Review Order

1. `#170` `feat: add notification foundation and battle text`
2. this PR `138B`
3. `138C` notification semantics finish-up

## Stack / Review Note

Because GitHub cannot base this PR on the fork branch from `#170` inside `netniV/stfc-mod`, this draft PR is based on `main`, so the overall diff includes the earlier `138A` commits.

For incremental review, use the compare link above.

## Validation

- `xmake b -y mods`
- `git diff --check origin/main...HEAD`
- `pwsh -NoProfile -File D:\dev\stfc-mod\.ax\ax.ps1 -RepoRoot D:\dev\netniv\stfc-mod cycle -BuildMode releasedbg`
- manual live pass on the deployed build:
  - arrival notification fired
  - node depleted notification fired
  - started mining stayed silent with the current config
  - docked stayed silent with the current config
