### PR TITLE
generate zstd artifacts for the new launcher to consume

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,18 @@ jobs:
       - name: Sign App Bundle
         run: codesign --force --verify --verbose --deep --sign "-" build/macosx/arm64/release/STFC\ Community\ Mod.app
 
+      - name: Package macOS mod archive
+        run: |
+          brew install zstd
+          mkdir -p stfc-community-mod-macos-universal
+          tar -cf - \
+            -C build/macosx/arm64/release/STFC\ Community\ Mod.app/Contents \
+            libstfc-community-mod.dylib \
+            | zstd -19 -T0 -o stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst
+          shasum -a 256 stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst \
+            | awk '{print $1}' \
+            > stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst.sha256
+
       - name: Install disk image creation tool
         run: brew install create-dmg
 
@@ -100,5 +112,13 @@ jobs:
         with:
           name: stfc-community-mod-installer
           path: stfc-community-mod-installer.dmg
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload macOS mod archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: stfc-community-mod-macos-universal
+          path: stfc-community-mod-macos-universal
           compression-level: 0
           if-no-files-found: error

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,17 @@ jobs:
         run: |
           (cd stfc-community-mod && zip -r - .) > stfc-community-mod.zip
 
+      - name: Package Windows mod archive
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zstd
+          mkdir -p stfc-community-mod-windows-x64
+          tar -cf - -C stfc-community-mod version.dll \
+            | zstd -19 -T0 -o stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst
+          sha256sum stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst \
+            | awk '{print $1}' \
+            > stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst.sha256
+
       # ✅ Step 4 — Detect prerelease (alpha/beta)
       - name: Check Prerelease
         id: check-prerelease
@@ -85,6 +96,46 @@ jobs:
           asset_path: ./stfc-community-mod.zip
           asset_name: stfc-community-mod-${{ github.ref_name }}.zip
           asset_content_type: application/zip
+
+      - name: Upload Community Mod - Windows Archive
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst
+          asset_name: stfc-community-mod-windows-x64.tar.zst
+          asset_content_type: application/zstd
+
+      - name: Upload Community Mod - Windows Archive Checksum
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst.sha256
+          asset_name: stfc-community-mod-windows-x64.tar.zst.sha256
+          asset_content_type: text/plain
+
+      - name: Upload Community Mod - macOS Archive
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst
+          asset_name: stfc-community-mod-macos-universal.tar.zst
+          asset_content_type: application/zstd
+
+      - name: Upload Community Mod - macOS Archive Checksum
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst.sha256
+          asset_name: stfc-community-mod-macos-universal.tar.zst.sha256
+          asset_content_type: text/plain
 
       - name: Upload Community Mod - Mac Installer
         uses: shogo82148/actions-upload-release-asset@v1


### PR DESCRIPTION
This is to let the new launcher pull a standalone copy of the mod instead of having to be bundled with it.