### PR TITLE
Fix crashes in sync's GameServerModelRegistry_ParseBinaryObjectsHelper

### DIFF
--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -2090,7 +2090,8 @@ void GameServerModelRegistry_ProcessResultInternal(auto original, void* _this, v
 }
 
 void GameServerModelRegistry_ParseBinaryObjectsHelper(auto original, void* _this, void* parsing_context,
-                                                       ServiceResponse* service_response, MethodInfo* method)
+                                                       ServiceResponse* service_response, void* parsedEntityTypes,
+                                                       MethodInfo* method)
 {
   auto *const entity_groups = service_response->EntityGroups;
   for (int i = 0; i < entity_groups->Count; ++i) {
@@ -2098,7 +2099,7 @@ void GameServerModelRegistry_ParseBinaryObjectsHelper(auto original, void* _this
     HandleEntityGroup(entity_group);
   }
 
-  return original(_this, parsing_context, service_response, method);
+  return original(_this, parsing_context, service_response, parsedEntityTypes, method);
 }
 
 void PrimeApp_InitPrimeServer(auto original, void* _this, Il2CppString* gameServerUrl, Il2CppString* gatewayServerUrl,

--- a/mods/src/version.h
+++ b/mods/src/version.h
@@ -3,7 +3,7 @@
 // clang-format off
 #define VERSION_MAJOR               1
 #define VERSION_MINOR               1
-#define VERSION_REVISION            1
+#define VERSION_REVISION            2
 #define VERSION_PATCH               1
 
 #define STRINGIFY_(s)               #s


### PR DESCRIPTION
In update 1.000.50187 (M91.9.0) the method signature of ServiceResponseModelRegistryBase::ParseBinaryObjectsHelper changed. This PR updates the method signature to prevent crashes.