### PR TITLE
Honour [patches] switches in release builds; make GameServer::Initialise sync hook optional

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -513,6 +513,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "patches", "resolutionlistfix", DCP::resolutionlistfix, write_config);
   this->installSyncPatches =
       get_config_or_default(config, parsed, "patches", "syncpatches", DCP::syncpatches, write_config);
+  this->installGameVersionHook =
+      get_config_or_default(config, parsed, "patches", "game_version", DCP::game_version, write_config);
   this->installObjectTracker =
       get_config_or_default(config, parsed, "patches", "objecttracker", DCP::objecttracker, write_config);
   this->installLoadingScreenBgHooks =
@@ -629,8 +631,6 @@ void Config::Load()
 
   this->sync_debug   = get_config_or_default(config, parsed, "sync", "debug", DCS::debug, write_config);
   this->sync_logging = get_config_or_default(config, parsed, "sync", "logging", DCS::logging, write_config);
-  this->sync_hook_game_version =
-      get_config_or_default(config, parsed, "sync", "hook_game_version", DCS::hook_game_version, write_config);
   this->sync_resolver_cache_ttl =
       get_config_or_default(config, parsed, "sync", "resolver_cache_ttl", DCS::resolver_cache_ttl, write_config);
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -484,7 +484,9 @@ void Config::Load()
     write_log    = false;
   }
 
-#if _MODDBG
+  // Patch switches are honoured in release builds too (previously debug-only):
+  // needed to selectively disable hook groups that collide with BepInEx plugins
+  // hooking the same il2cpp methods (native + managed detour on one prologue crashes).
   this->installUiScaleHooks =
       get_config_or_default(config, parsed, "patches", "uiscalehooks", DCP::uiscalehooks, write_config);
   this->installZoomHooks = get_config_or_default(config, parsed, "patches", "zoomhooks", DCP::zoomhooks, write_config);
@@ -516,24 +518,6 @@ void Config::Load()
   this->installLoadingScreenBgHooks =
       get_config_or_default(config, parsed, "patches", "loadingscreenbghooks", DCP::loadingscreenbghooks, write_config);
   spdlog::debug("");
-#else
-  this->installUiScaleHooks               = true;
-  this->installZoomHooks                  = true;
-  this->installBuffFixHooks               = true;
-  this->installToastBannerHooks           = true;
-  this->installPanHooks                   = true;
-  this->installImproveResponsivenessHooks = true;
-  this->installHotkeyHooks                = true;
-  this->installFreeResizeHooks            = true;
-  this->installTempCrashFixes             = true;
-  this->installTestPatches                = true;
-  this->installMiscPatches                = true;
-  this->installChatPatches                = true;
-  this->installResolutionListFix          = false; // this patch does not work after unity 6 update
-  this->installSyncPatches                = true;
-  this->installObjectTracker              = true;
-  this->installLoadingScreenBgHooks       = true;
-#endif
 
   this->queue_enabled =
       get_config_or_default(config, parsed, "control", "queue_enabled", DCC::queue_enabled, write_config);
@@ -645,6 +629,8 @@ void Config::Load()
 
   this->sync_debug   = get_config_or_default(config, parsed, "sync", "debug", DCS::debug, write_config);
   this->sync_logging = get_config_or_default(config, parsed, "sync", "logging", DCS::logging, write_config);
+  this->sync_hook_game_version =
+      get_config_or_default(config, parsed, "sync", "hook_game_version", DCS::hook_game_version, write_config);
   this->sync_resolver_cache_ttl =
       get_config_or_default(config, parsed, "sync", "resolver_cache_ttl", DCS::resolver_cache_ttl, write_config);
 

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -184,6 +184,7 @@ public:
 
   bool       sync_logging;
   bool       sync_debug;
+  bool       sync_hook_game_version;
   int        sync_resolver_cache_ttl;
   SyncConfig sync_options;
 

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -184,7 +184,6 @@ public:
 
   bool       sync_logging;
   bool       sync_debug;
-  bool       sync_hook_game_version;
   int        sync_resolver_cache_ttl;
   SyncConfig sync_options;
 
@@ -204,6 +203,7 @@ public:
   bool installChatPatches;
   bool installResolutionListFix;
   bool installSyncPatches;
+  bool installGameVersionHook;
   bool installObjectTracker;
 
   std::string config_settings_url;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -55,6 +55,7 @@ namespace Patches
   constexpr bool bufffixhooks               = true;
   constexpr bool chatpatches                = true;
   constexpr bool freeresizehooks            = true;
+  constexpr bool game_version               = true;
   constexpr bool hotkeyhooks                = true;
   constexpr bool improveresponsivenesshooks = true;
   constexpr bool miscpatches                = true;
@@ -169,7 +170,6 @@ namespace Sync
   constexpr bool        battlelogs         = true;
   constexpr bool        buffs              = true;
   constexpr bool        buildings          = true;
-  constexpr bool        hook_game_version  = true;
   constexpr bool        inventory          = true;
   constexpr bool        jobs               = true;
   constexpr bool        missions           = true;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -169,6 +169,7 @@ namespace Sync
   constexpr bool        battlelogs         = true;
   constexpr bool        buffs              = true;
   constexpr bool        buildings          = true;
+  constexpr bool        hook_game_version  = true;
   constexpr bool        inventory          = true;
   constexpr bool        jobs               = true;
   constexpr bool        missions           = true;

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -2314,8 +2314,8 @@ void InstallSyncPatches()
     // (headers::primeVersion has a static fallback). It is optional so users can turn
     // it off when another mod detours the same method — a native and a managed detour
     // on one prologue corrupt each other and crash at login.
-    if (!Config::Get().sync_hook_game_version) {
-      spdlog::info("Sync: skipping GameServer::Initialise hook (sync.hook_game_version = false)");
+    if (!Config::Get().installGameVersionHook) {
+      spdlog::info("Sync: skipping GameServer::Initialise hook (patches.game_version = false)");
     } else if (auto *const ptr = game_server.GetMethod("Initialise"); ptr == nullptr) {
       ErrorMsg::MissingMethod("GameServer", "Initialise");
     } else {

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -2310,7 +2310,13 @@ void InstallSyncPatches()
       !game_server.isValidHelper()) {
     ErrorMsg::MissingHelper("Core", "GameServer");
   } else {
-    if (auto *const ptr = game_server.GetMethod("Initialise"); ptr == nullptr) {
+    // This hook only captures the game version for the X-PRIME-VERSION sync header
+    // (headers::primeVersion has a static fallback). It is optional so users can turn
+    // it off when another mod detours the same method — a native and a managed detour
+    // on one prologue corrupt each other and crash at login.
+    if (!Config::Get().sync_hook_game_version) {
+      spdlog::info("Sync: skipping GameServer::Initialise hook (sync.hook_game_version = false)");
+    } else if (auto *const ptr = game_server.GetMethod("Initialise"); ptr == nullptr) {
       ErrorMsg::MissingMethod("GameServer", "Initialise");
     } else {
       SPUD_STATIC_DETOUR(ptr, GameServer_Initialise);


### PR DESCRIPTION
## What

Two small changes that let users resolve hook collisions with other mods via config instead of rebuilding:

- **config.cc**: read the `[patches]` hook-group switches in release builds too. Previously they were only compiled in under `_MODDBG`; release builds hardcoded every group on. **Defaults are unchanged** — without any `[patches]` entries the behaviour is identical to before (including `resolutionlistfix` staying off).
- **sync.cc**: new switch `[patches] game_version` (default `true`) to skip only the `GameServer::Initialise` detour. That hook solely captures the game version for the `X-PRIME-VERSION` sync header, which has a static fallback (`headers::primeVersion`), so skipping it degrades gracefully — session id and instance id capture are untouched.

## Why

Other BepInEx/Harmony-based mods may detour the same il2cpp methods as this mod. A native detour (this mod) and a managed detour (Il2CppInterop/Harmony) installed on the same method prologue corrupt each other's trampoline and crash the client during login with an `AccessViolationException` in `il2cpp_runtime_invoke`. With these switches, affected users can turn off just the overlapping hook group on this side and keep every other feature (including the rest of sync).

## Testing

- Built via the repo CI workflow (Windows).
- Verified on client 1.000.50475 / Unity 6000.0.59f2 / BepInEx 6.0.0-be.755:
  - Without config entries: log shows the same Patching/Skipping sequence as the official 1.1.2 build (defaults unchanged).
  - With `[patches] uiscalehooks = false` and the game version hook disabled: log shows `x Skipping 1 of 16 (UiScaleHooks)` and `Sync: skipping GameServer::Initialise hook`; a plugin combination that previously crashed at login (double detour) now runs stably, sync uploads keep working.
  - Note: the in-game run used the switch under its initial name `[sync] hook_game_version`; per review it is now `[patches] game_version` — the rename only moves where the flag is read, the gated code path is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
