### PR TITLE
feat: add CTRL-F search shortcut and comprehensive null checks

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -227,6 +227,7 @@ uiscalehooks = true
 zoomhooks = true
 loadingscreenhooks = true
 transitionscreenhooks = true
+focussearch = true
 
 #  <[=========================================================================================================================================]>
 #
@@ -302,6 +303,9 @@ select_ship7 = "7"
 
 # See select_timer
 select_ship8 = "8"
+
+# Focus the search input field in the current view
+focus_search = "CTRL-F"
 
 # Subgroup: Experimental
 # ----------------------

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -521,6 +521,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "patches", "transitionscreenhooks", DCP::transitionscreenhooks, write_config);
   this->installGiftsBulkClaimHooks =
       get_config_or_default(config, parsed, "patches", "giftsbulkclaimhooks", DCP::giftsbulkclaimhooks, write_config);
+  this->installFocusSearchHooks =
+      get_config_or_default(config, parsed, "patches", "focussearch", DCP::focussearch, write_config);
   spdlog::debug("");
 
   this->queue_enabled =
@@ -811,6 +813,7 @@ void Config::Load()
   parse_config_shortcut(config, parsed, "select_ship7", GameFunction::SelectShip7, DCSH::select_ship7);
   parse_config_shortcut(config, parsed, "select_ship8", GameFunction::SelectShip8, DCSH::select_ship8);
   parse_config_shortcut(config, parsed, "select_current", GameFunction::SelectCurrent, DCSH::select_current);
+  parse_config_shortcut(config, parsed, "focus_search", GameFunction::FocusSearch, DCSH::focus_search);
 
   parse_config_shortcut(config, parsed, "action_primary", GameFunction::ActionPrimary, DCSH::action_primary);
   parse_config_shortcut(config, parsed, "action_secondary", GameFunction::ActionSecondary, DCSH::action_secondary);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -220,4 +220,5 @@ public:
 
   bool installLoadingScreenHooks;
   bool installTransitionScreenHooks;
+  bool installFocusSearchHooks;
 };

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -77,6 +77,7 @@ namespace Patches
   constexpr bool zoomhooks                  = true;
   constexpr bool miscpatches                = true;
   constexpr bool giftsbulkclaimhooks        = true;
+  constexpr bool focussearch                = true;
 } // namespace Patches
 
 namespace Shortcuts
@@ -111,6 +112,7 @@ namespace Shortcuts
   constexpr const char* select_ship6          = "6";
   constexpr const char* select_ship7          = "7";
   constexpr const char* select_ship8          = "8";
+  constexpr const char* focus_search          = "CTRL-F";
   constexpr const char* set_zoom_default      = "CTRL-=";
   constexpr const char* set_zoom_preset1      = "SHIFT-F1";
   constexpr const char* set_zoom_preset2      = "SHIFT-F2";

--- a/mods/src/patches/gamefunctions.h
+++ b/mods/src/patches/gamefunctions.h
@@ -91,6 +91,7 @@ enum GameFunction {
   LogLevelWarn,
   LogLevelOff,
   Quit,
+  FocusSearch,
 
   // Automatic max value
   Max

--- a/mods/src/patches/parts/focus_search.cc
+++ b/mods/src/patches/parts/focus_search.cc
@@ -1,0 +1,103 @@
+#include "focus_search.h"
+
+#include "config.h"
+
+#include "prime/AssignShipsWidget.h"
+#include "prime/CanvasController.h"
+#include "prime/ChatMessageListLocalViewController.h"
+#include "prime/InventoryListViewController.h"
+#include "prime/OfficerAssignmentViewController.h"
+
+#include "il2cpp/il2cpp_helper.h"
+
+#include <spdlog/spdlog.h>
+
+bool FocusSearchBox()
+{
+  if (!Config::Get().installFocusSearchHooks) {
+    return false;
+  }
+
+  // Guard chat input so we don't steal focus from the chat text box
+  if (auto chat = ObjectFinder<ChatMessageListLocalViewController>::Get(); chat && chat->_inputFieldSelected) {
+#ifdef _MODDBG
+    spdlog::info("[FocusSearch] blocked: chat input is selected");
+#endif
+    return false;
+  }
+
+  // InventoryListViewController covers OfficerRosterViewController and other inventory subclasses
+  auto inventoryControllers = ObjectFinder<InventoryListViewController>::GetAll();
+  for (auto controller : inventoryControllers) {
+    if (!controller || !controller->_inputField) {
+      continue;
+    }
+
+    auto canvas  = controller->canvasController;
+    bool visible = canvas && canvas->Visible();
+    bool active  = controller->isActiveAndEnabled && controller->_inputField->isActiveAndEnabled;
+    spdlog::debug("[FocusSearch] inventory controller={} section={} canvas={} visible={} active={}", (void*)controller,
+                 (int32_t)controller->_targetSection, (void*)canvas, visible, active);
+
+    if (visible && active) {
+#ifdef _MODDBG
+      spdlog::info("[FocusSearch] focusing visible inventory search");
+#endif
+      controller->_inputField->Focus();
+      return true;
+    }
+  }
+
+  // OfficerAssignmentViewController (separate from inventory list)
+  auto officerControllers = ObjectFinder<OfficerAssignmentViewController>::GetAll();
+  for (auto controller : officerControllers) {
+    if (!controller || !controller->_inputField) {
+      continue;
+    }
+
+    auto canvas  = controller->canvasController;
+    bool visible = canvas && canvas->Visible();
+    bool active  = controller->isActiveAndEnabled && controller->_inputField->isActiveAndEnabled;
+    spdlog::debug("[FocusSearch] officer assignment controller={} canvas={} visible={} active={}", (void*)controller,
+                 (void*)canvas, visible, active);
+
+    if (visible && active) {
+#ifdef _MODDBG
+      spdlog::info("[FocusSearch] focusing visible officer assignment search");
+#endif
+      controller->_inputField->Focus();
+      return true;
+    }
+  }
+
+  // AssignShipsWidget (ship selection / assignment)
+  auto assignShipWidgets = ObjectFinder<AssignShipsWidget>::GetAll();
+  for (auto widget : assignShipWidgets) {
+    if (!widget || !widget->_inputField) {
+      continue;
+    }
+
+    auto canvas  = GetCanvasControllerFromComponent(widget);
+    bool visible = canvas && canvas->Visible();
+    bool active  = widget->isActiveAndEnabled && widget->_inputField->isActiveAndEnabled;
+    spdlog::debug("[FocusSearch] assign ships widget={} canvas={} visible={} active={}", (void*)widget, (void*)canvas,
+                 visible, active);
+
+    if (visible && active) {
+#ifdef _MODDBG
+      spdlog::info("[FocusSearch] focusing visible assign ships search");
+#endif
+      widget->_inputField->Focus();
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void InstallFocusSearchHooks()
+{
+#ifdef _MODDBG
+  spdlog::info("[FocusSearch] installed");
+#endif
+}

--- a/mods/src/patches/parts/focus_search.h
+++ b/mods/src/patches/parts/focus_search.h
@@ -1,0 +1,4 @@
+#pragma once
+
+bool FocusSearchBox();
+void InstallFocusSearchHooks();

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -170,7 +170,11 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
         if (can_locate && ship_select_request == last_ship_select_request
             && fleet_bar->IsIndexSelected(ship_select_request)
             && select_diff < std::chrono::milliseconds((int)Config::Get().select_timer)) {
-          auto fleet = fleet_bar->_fleetPanelController->fleet;
+          auto fleet_controller = fleet_bar->_fleetPanelController;
+          auto fleet            = fleet_controller ? fleet_controller->fleet : nullptr;
+          if (!fleet) {
+            return;
+          }
           if (NavigationSectionManager::Instance() && NavigationSectionManager::Instance()->SNavigationManager) {
             NavigationSectionManager::Instance()->SNavigationManager->HideInteraction();
           }
@@ -198,7 +202,8 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
       if (MapKey::IsDown(GameFunction::SelectCurrent)) {
         auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
         if (fleet_bar) {
-          auto fleet = fleet_bar->_fleetPanelController->fleet;
+          auto fleet_controller = fleet_bar->_fleetPanelController;
+          auto fleet            = fleet_controller ? fleet_controller->fleet : nullptr;
           if (fleet) {
             if (NavigationSectionManager::Instance() && NavigationSectionManager::Instance()->SNavigationManager) {
               NavigationSectionManager::Instance()->SNavigationManager->HideInteraction();
@@ -356,9 +361,9 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
         spdlog::flush_on(spdlog::level::trace);
         // spdlog::log("Setting log level to TRACE");
       } else if (MapKey::IsDown(GameFunction::ShowShips)) {
-        auto fleet_bar        = ObjectFinder<FleetBarViewController>::Get();
-        auto fleet_controller = fleet_bar->_fleetPanelController;
-        auto fleet            = fleet_bar->_fleetPanelController->fleet;
+        auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
+        auto fleet_controller = fleet_bar ? fleet_bar->_fleetPanelController : nullptr;
+        auto fleet            = fleet_controller ? fleet_controller->fleet : nullptr;
         if (fleet) {
           fleet_controller->RequestAction(fleet, ActionType::Manage, 0, ActionBehaviour::Default);
         }
@@ -411,15 +416,18 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
       auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
 
       for (auto& pre_scan_widget : all_pre_scan_widgets) {
-        if (pre_scan_widget
-            && (pre_scan_widget->_visibilityController->_state == VisibilityState::Visible
-                || pre_scan_widget->_visibilityController->_state == VisibilityState::Show)) {
-          auto rewardsWidget = pre_scan_widget->_rewardsButtonWidget;
-          if (rewardsWidget->_rewardsController->_state != VisibilityState::Visible
-              && rewardsWidget->_rewardsController->_state != VisibilityState::Show) {
+        auto visibility_controller = pre_scan_widget ? pre_scan_widget->_visibilityController : nullptr;
+        auto rewardsWidget         = pre_scan_widget ? pre_scan_widget->_rewardsButtonWidget : nullptr;
+        auto rewards_controller    = rewardsWidget ? rewardsWidget->_rewardsController : nullptr;
+        if (visibility_controller
+            && (visibility_controller->_state == VisibilityState::Visible
+                || visibility_controller->_state == VisibilityState::Show)
+            && rewards_controller) {
+          if (rewards_controller->_state != VisibilityState::Visible
+              && rewards_controller->_state != VisibilityState::Show) {
             show_info_pending = 5;
           } else {
-            rewardsWidget->_rewardsController->Hide();
+            rewards_controller->Hide();
           }
         }
       }
@@ -430,15 +438,17 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
       auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
 
       for (auto& pre_scan_widget : all_pre_scan_widgets) {
-        const auto pre_scan_visible = pre_scan_widget
-                                      && (pre_scan_widget->_visibilityController->_state == VisibilityState::Visible
-                                          || pre_scan_widget->_visibilityController->_state == VisibilityState::Show);
-        if (pre_scan_visible) {
-          auto       rewardsWidget          = pre_scan_widget->_rewardsButtonWidget;
-          const auto rewards_widget_visible = rewardsWidget->_rewardsController->_state == VisibilityState::Visible
-                                              || rewardsWidget->_rewardsController->_state == VisibilityState::Show;
+        auto visibility_controller = pre_scan_widget ? pre_scan_widget->_visibilityController : nullptr;
+        auto rewardsWidget         = pre_scan_widget ? pre_scan_widget->_rewardsButtonWidget : nullptr;
+        auto rewards_controller    = rewardsWidget ? rewardsWidget->_rewardsController : nullptr;
+        const auto pre_scan_visible = visibility_controller
+                                      && (visibility_controller->_state == VisibilityState::Visible
+                                          || visibility_controller->_state == VisibilityState::Show);
+        if (pre_scan_visible && rewards_controller) {
+          const auto rewards_widget_visible = rewards_controller->_state == VisibilityState::Visible
+                                              || rewards_controller->_state == VisibilityState::Show;
           if (!rewards_widget_visible) {
-            rewardsWidget->_rewardsController->Show(true);
+            rewards_controller->Show(true);
           }
         }
       }
@@ -535,8 +545,15 @@ inline bool DidExecuteFleetAction(std::string_view actionText, ActionType action
                                   const std::span<const FleetState> wantedStates,
                                   FleetState                        helpState = FleetState::Unknown)
 {
+  if (!fleet_bar) {
+    return false;
+  }
+
   auto fleet_controller = fleet_bar->_fleetPanelController;
-  auto fleet            = fleet_bar->_fleetPanelController->fleet;
+  auto fleet            = fleet_controller ? fleet_controller->fleet : nullptr;
+  if (!fleet) {
+    return false;
+  }
   auto fleet_state      = fleet->CurrentState;
 
   auto       fleet_id   = fleet->Id;
@@ -590,10 +607,20 @@ bool DidExecuteRepair(FleetBarViewController* fleet_bar)
 
 void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
 {
+  if (!fleet_bar) {
+    return;
+  }
+
   auto fleet_controller = fleet_bar->_fleetPanelController;
-  auto fleet            = fleet_controller->fleet;
+  auto fleet            = fleet_controller ? fleet_controller->fleet : nullptr;
+  if (!fleet) {
+    return;
+  }
 
   auto action_queue = ActionQueueManager::Instance();
+  if (!action_queue) {
+    return;
+  }
 
   auto has_primary       = MapKey::IsDown(GameFunction::ActionPrimary) || force_space_action_next_frame;
   auto has_repair        = MapKey::IsDown(GameFunction::ActionRepair);
@@ -612,15 +639,16 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
   } else {
     auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
     for (auto pre_scan_widget : all_pre_scan_widgets) {
-      if (pre_scan_widget
-          && (pre_scan_widget->_visibilityController->_state == VisibilityState::Visible
-              || pre_scan_widget->_visibilityController->_state == VisibilityState::Show)) {
+      auto visibility_controller = pre_scan_widget ? pre_scan_widget->_visibilityController : nullptr;
+      if (visibility_controller
+          && (visibility_controller->_state == VisibilityState::Visible
+              || visibility_controller->_state == VisibilityState::Show)) {
 
         if (auto mine_object_viewer_widget = ObjectFinder<MiningObjectViewerWidget>::Get();
-            mine_object_viewer_widget
+            mine_object_viewer_widget && mine_object_viewer_widget->_visibilityController
             && (mine_object_viewer_widget->_visibilityController->_state == VisibilityState::Visible
                 || mine_object_viewer_widget->_visibilityController->_state == VisibilityState::Show)) {
-          if (has_secondary) {
+          if (has_secondary && pre_scan_widget->_scanEngageButtonsWidget) {
             return pre_scan_widget->_scanEngageButtonsWidget->OnScanButtonClicked();
           } else if (has_primary) {
             return mine_object_viewer_widget->MineClicked();
@@ -652,7 +680,7 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
           }
         }
 
-        if (has_secondary) {
+        if (has_secondary && pre_scan_widget->_scanEngageButtonsWidget) {
           return pre_scan_widget->_scanEngageButtonsWidget->OnScanButtonClicked();
         }
 
@@ -711,10 +739,10 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
     }
 
     if (auto mine_object_viewer_widget = ObjectFinder<MiningObjectViewerWidget>::Get();
-        mine_object_viewer_widget
+        mine_object_viewer_widget && mine_object_viewer_widget->_visibilityController
         && (mine_object_viewer_widget->_visibilityController->_state == VisibilityState::Visible
             || mine_object_viewer_widget->_visibilityController->_state == VisibilityState::Show)) {
-      if (has_secondary) {
+      if (has_secondary && mine_object_viewer_widget->_scanEngageButtonsWidget) {
         if (mine_object_viewer_widget->_scanEngageButtonsWidget->Context) {
           return mine_object_viewer_widget->_scanEngageButtonsWidget->OnScanButtonClicked();
         }
@@ -797,7 +825,7 @@ void InitializeActions_Hook(auto original, void* _this)
 
 bool CheckShowCargo(RewardsButtonWidget* widget)
 {
-  if (!Config::Get().show_cargo_default) {
+  if (!widget || !Config::Get().show_cargo_default) {
     return false;
   }
 
@@ -826,14 +854,20 @@ bool CheckShowCargo(RewardsButtonWidget* widget)
 
 void OnDidBindContext_Hook(auto original, RewardsButtonWidget* _this)
 {
-  auto pre_state = _this->_rewardsController->_state;
-  pre_state      = pre_state;
+  if (!_this) {
+    return original(_this);
+  }
+
+  auto rewards_controller = _this->_rewardsController;
+  auto pre_state          = rewards_controller ? rewards_controller->_state : VisibilityState::Unknown;
+  pre_state               = pre_state;
   original(_this);
 
-  auto post_state = _this->_rewardsController->_state;
+  rewards_controller = _this->_rewardsController;
+  auto post_state = rewards_controller ? rewards_controller->_state : VisibilityState::Unknown;
   post_state      = post_state;
-  if (CheckShowCargo(_this)) {
-    _this->_rewardsController->Show(true);
+  if (rewards_controller && CheckShowCargo(_this)) {
+    rewards_controller->Show(true);
     show_info_pending = 1;
   }
 }
@@ -841,9 +875,14 @@ void OnDidBindContext_Hook(auto original, RewardsButtonWidget* _this)
 void ShowWithFleet_Hook(auto original, PreScanTargetWidget* _this, void* a1)
 {
   original(_this, a1);
+  if (!_this) {
+    return;
+  }
+
   auto rewards_button_widget = _this->_rewardsButtonWidget;
-  if (CheckShowCargo(rewards_button_widget)) {
-    rewards_button_widget->_rewardsController->Show(true);
+  auto rewards_controller    = rewards_button_widget ? rewards_button_widget->_rewardsController : nullptr;
+  if (rewards_controller && CheckShowCargo(rewards_button_widget)) {
+    rewards_controller->Show(true);
     show_info_pending = 1;
   }
 }

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -17,7 +17,6 @@
 #include "prime/ElementSelectorViewController.h"
 #include "prime/BookmarksManager.h"
 #include "prime/ChatManager.h"
-#include "prime/ChatMessageListLocalViewController.h"
 #include "prime/DeploymentManager.h"
 #include "prime/FleetBarViewController.h"
 #include "prime/FleetLocalViewController.h"
@@ -33,6 +32,7 @@
 
 #include "patches/key.h"
 #include "patches/mapkey.h"
+#include "patches/parts/focus_search.h"
 
 #include <EASTL/vector.h>
 
@@ -243,6 +243,12 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
       if (MapKey::IsDown(GameFunction::MoveRight)) {
         auto const result = MoveOfficerCanvas(false);
         if (result) {
+          return;
+        }
+      }
+
+      if (Config::Get().installFocusSearchHooks && MapKey::IsDown(GameFunction::FocusSearch)) {
+        if (FocusSearchBox()) {
           return;
         }
       }

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -20,19 +20,20 @@
 #include <prime/ActionQueueManager.h>
 #include <prime/InterstitialViewController.h>
 
-int64_t InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, int64_t a2)
+void InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, int64_t a2)
 {
+  if (!a1) {
+    return;
+  }
+
   if (a1->IsDonationUse && a2 == 50 && Config::Get().extend_donation_slider) {
     const auto max = Config::Get().extend_donation_max;
     if (max > 0) {
       a2 = max;
-    } else {
-      return -1;
     }
   }
 
-  int64_t standard = original(a1, a2);
-  return standard;
+  original(a1, a2);
 }
 
 void BundleDataWidget_OnActionButtonPressedCallback(auto original, BundleDataWidget* _this)
@@ -93,6 +94,9 @@ struct ResolutionArray {
 ResolutionArray* GetResolutions_Hook(auto original)
 {
   auto resolutions = original();
+  if (!resolutions) {
+    return nullptr;
+  }
 
 #if _WIN32
   // Modify
@@ -120,12 +124,11 @@ ResolutionArray* GetResolutions_Hook(auto original)
 
   res.erase(unique(res.begin(), res.end()), res.end());
 
-  int i = 0;
-  for (const auto& resultRes : res) {
-    resolutions->data[i] = resultRes;
-    ++i;
+  const auto result_count = std::min(res.size(), resolutions->maxlength);
+  for (size_t i = 0; i < result_count; ++i) {
+    resolutions->data[i] = res[i];
   }
-  resolutions->maxlength = res.size();
+  resolutions->maxlength = result_count;
 #endif
 
   return resolutions;

--- a/mods/src/patches/parts/object_tracker.cc
+++ b/mods/src/patches/parts/object_tracker.cc
@@ -3,12 +3,15 @@
 #include "prime/AllianceStarbaseObjectViewerWidget.h"
 #include "prime/AnimatedRewardsScreenViewController.h"
 #include "prime/ArmadaObjectViewerWidget.h"
+#include "prime/AssignShipsWidget.h"
 #include "prime/CelestialObjectViewerWidget.h"
 #include "prime/EmbassyObjectViewer.h"
 #include "prime/FleetBarViewController.h"
 #include "prime/FullScreenChatViewController.h"
 #include "prime/HousingObjectViewerWidget.h"
+#include "prime/InventoryListViewController.h"
 #include "prime/MiningObjectViewerWidget.h"
+#include "prime/OfficerAssignmentViewController.h"
 #include "prime/MissionsObjectViewerWidget.h"
 #include "prime/NavigationInteractionUIViewController.h"
 #include "prime/PreScanTargetWidget.h"
@@ -174,13 +177,16 @@ void InstallObjectTrackers()
   TrackObject<AllianceStarbaseObjectViewerWidget>();
   TrackObject<AnimatedRewardsScreenViewController>();
   TrackObject<ArmadaObjectViewerWidget>();
+  TrackObject<AssignShipsWidget>();
   TrackObject<CelestialObjectViewerWidget>();
   TrackObject<EmbassyObjectViewer>();
   TrackObject<FullScreenChatViewController>();
   TrackObject<HousingObjectViewerWidget>();
+  TrackObject<InventoryListViewController>();
   TrackObject<MiningObjectViewerWidget>();
   TrackObject<MissionsObjectViewerWidget>();
   TrackObject<NavigationInteractionUIViewController>();
+  TrackObject<OfficerAssignmentViewController>();
   TrackObject<ElementSelectorViewController>();
   TrackObject<StarNodeObjectViewerWidget>();
 

--- a/mods/src/patches/parts/object_tracker.cc
+++ b/mods/src/patches/parts/object_tracker.cc
@@ -73,8 +73,18 @@ void (*GC_register_finalizer_inner)(unsigned __int64 obj, void (*fn)(void*, void
 
 void track_finalizer(void* _this, void*)
 {
+  if (_this == nullptr) {
+    return;
+  }
+
+  auto object = (Il2CppObject*)_this;
+  if (object->klass == nullptr) {
+    remove_from_tracking_all(_this);
+    return;
+  }
+
 #define GET_CLASS(obj) ((Il2CppClass*)(((size_t)obj) & ~(size_t)1))
-  spdlog::trace("Clearing {}({})", (void*)_this, GET_CLASS(((Il2CppObject*)_this)->klass)->name);
+  spdlog::trace("Clearing {}({})", (void*)_this, GET_CLASS(object->klass)->name);
   remove_from_tracking_all(_this);
 #undef GET_CLASS
 }
@@ -86,14 +96,20 @@ void* track_ctor(auto original, void* _this)
     return _this;
   }
 
+  auto cls = (Il2CppObject*)_this;
+  if (cls->klass == nullptr) {
+    return obj;
+  }
+
   std::scoped_lock lk{tracked_objects_mutex};
-  auto             cls = (Il2CppObject*)_this;
   spdlog::trace("Tracking {}({})", _this, cls->klass->name);
-  typedef void      (*FinalizerCallback)(void* object, void* client_data);
-  FinalizerCallback oldCallback = nullptr;
-  void*             oldData     = nullptr;
-  GC_register_finalizer_inner((intptr_t)_this, track_finalizer, nullptr, &oldCallback, &oldData);
-  assert(!oldCallback);
+  if (GC_register_finalizer_inner != nullptr) {
+    typedef void (*FinalizerCallback)(void* object, void* client_data);
+    FinalizerCallback oldCallback = nullptr;
+    void*             oldData     = nullptr;
+    GC_register_finalizer_inner((intptr_t)_this, track_finalizer, nullptr, &oldCallback, &oldData);
+    assert(!oldCallback);
+  }
   add_to_tracking_recursive(cls->klass, _this);
   return obj;
 }
@@ -204,6 +220,11 @@ void InstallObjectTrackers()
       "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 83 EC ? 4C 89 45 ? 48 89 4D ? 83 3D", "GameAssembly.dylib");
 #endif
 #endif
+
+  if (GC_register_finalizer_inner_matches.size() == 0) {
+    spdlog::warn("Unable to resolve GC_register_finalizer_inner; object finalizers disabled");
+    return;
+  }
 
   const auto GC_register_finalizer_inner_match = GC_register_finalizer_inner_matches.get(0);
   GC_register_finalizer_inner = (decltype(GC_register_finalizer_inner))GC_register_finalizer_inner_match.address();

--- a/mods/src/patches/parts/testing.cc
+++ b/mods/src/patches/parts/testing.cc
@@ -115,6 +115,9 @@ AppConfig* Model_LoadConfigs(auto original, Model* _this)
 {
   original(_this);
   auto config = _this->AppConfig_;
+  if (!config) {
+    return nullptr;
+  }
 
   if (!Config::Get().config_settings_url.empty()) {
     auto new_settings_url       = il2cpp_string_new(Config::Get().config_settings_url.c_str());

--- a/mods/src/patches/parts/ui_scale.cc
+++ b/mods/src/patches/parts/ui_scale.cc
@@ -54,9 +54,15 @@ void ScreenManager_UpdateCanvasRootScaleFactor_Hook(auto original, ScreenManager
 void CanvasController_Show(auto original, CanvasController* _this, int desiredEntryPoint, bool instant)
 {
   const auto ui_scale_viewer = Config::Get().ui_scale_viewer;
-  if (ui_scale_viewer != 0.0f && to_wstring(_this->name) == L"ObjectViewerTemplate_Canvas") {
-    auto transform        = _this->transform;
-    auto localScale       = transform->localScale;
+  if (_this && ui_scale_viewer != 0.0f && to_wstring(_this->name) == L"ObjectViewerTemplate_Canvas") {
+    auto transform = _this->transform;
+    if (transform == nullptr) {
+      return original(_this, desiredEntryPoint, instant);
+    }
+    auto localScale = transform->localScale;
+    if (localScale == nullptr) {
+      return original(_this, desiredEntryPoint, instant);
+    }
     localScale->x         = ui_scale_viewer;
     localScale->y         = ui_scale_viewer;
     localScale->z         = ui_scale_viewer;

--- a/mods/src/patches/parts/zoom.cc
+++ b/mods/src/patches/parts/zoom.cc
@@ -18,10 +18,19 @@ vec3 GetMouseWorldPos(void *cam, vec3 *pos)
   static auto class_helper = il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.Client.Core", "MathUtils");
   static auto fn           = class_helper.GetMethodInfo("GetMouseWorldPos");
 
+  if (fn == nullptr || cam == nullptr || pos == nullptr) {
+    return {0.0f, 0.0f, 0.0f};
+  }
+
   void            *args[2]   = {cam, (void *)pos};
-  Il2CppException *exception = NULL;
+  Il2CppException *exception = nullptr;
   auto             result    = il2cpp_runtime_invoke(fn, nullptr, args, &exception);
-  return *(vec3 *)(il2cpp_object_unbox(result));
+  if (exception != nullptr || result == nullptr) {
+    return {0.0f, 0.0f, 0.0f};
+  }
+
+  auto unboxed = il2cpp_object_unbox(result);
+  return unboxed != nullptr ? *reinterpret_cast<vec3 *>(unboxed) : vec3{0.0f, 0.0f, 0.0f};
 }
 
 auto do_default_zoom = false;

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -39,6 +39,7 @@ void InstallObjectTrackers();
 void InstallLoadingScreenHooks();
 void InstallTransitionScreenHooks();
 void InstallLoadingTipHooks();
+void InstallFocusSearchHooks();
 
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
 {
@@ -124,6 +125,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"LoadingScreen",        {InstallLoadingScreenHooks,   &cfg.installLoadingScreenHooks}},
       {"TransitionScreen",     {InstallTransitionScreenHooks, &cfg.installTransitionScreenHooks}},
       {"LoadingTip",           {InstallLoadingTipHooks,       &cfg.loader_tip_enabled}},
+      {"FocusSearch",          {InstallFocusSearchHooks,      &cfg.installFocusSearchHooks}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);
 

--- a/mods/src/prime/AssignShipsWidget.h
+++ b/mods/src/prime/AssignShipsWidget.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+#include "InputFieldWidget.h"
+
+struct AssignShipsWidget {
+public:
+  __declspec(property(get = __get__inputField)) InputFieldWidget* _inputField;
+  __declspec(property(get = __get_isActiveAndEnabled)) bool        isActiveAndEnabled;
+
+private:
+  friend class ObjectFinder<AssignShipsWidget>;
+
+public:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Ships", "AssignShipsWidget");
+    return class_helper;
+  }
+
+  InputFieldWidget* __get__inputField()
+  {
+    static auto field = get_class_helper().GetField("_inputField").offset();
+    return *(InputFieldWidget**)((uintptr_t)this + field);
+  }
+
+  bool __get_isActiveAndEnabled()
+  {
+    static auto field = get_class_helper().GetProperty("isActiveAndEnabled");
+    return field.Get<bool>(this);
+  }
+};

--- a/mods/src/prime/CanvasController.h
+++ b/mods/src/prime/CanvasController.h
@@ -2,6 +2,8 @@
 
 #include <il2cpp/il2cpp_helper.h>
 
+#include "errormsg.h"
+
 #include "Canvas.h"
 #include "Transform.h"
 
@@ -67,3 +69,27 @@ private:
     return class_helper;
   }
 };
+
+inline CanvasController* GetCanvasControllerFromComponent(void* component)
+{
+  if (!component) {
+    return nullptr;
+  }
+
+  static auto component_class = il2cpp_get_class_helper("UnityEngine.CoreModule", "UnityEngine", "Component");
+  static auto method          = component_class.GetMethodInfo("GetComponentInParent", 1);
+  if (!method) {
+    return nullptr;
+  }
+
+  static auto canvas_type = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "CanvasController").GetType();
+
+  Il2CppException* exception = nullptr;
+  void*            params[1] = {canvas_type};
+  auto             result    = il2cpp_runtime_invoke(method, component, params, &exception);
+  if (exception) {
+    spdlog::error("[CanvasController] GetComponentInParent threw an exception");
+    return nullptr;
+  }
+  return (CanvasController*)result;
+}

--- a/mods/src/prime/ChatMessageListLocalViewController.h
+++ b/mods/src/prime/ChatMessageListLocalViewController.h
@@ -28,10 +28,13 @@ public:
 struct ChatMessageListLocalViewController {
 public:
   __declspec(property(get = __get__inputField)) TMP_InputField* _inputField;
+  __declspec(property(get = __get__inputFieldSelected)) bool _inputFieldSelected;
   __declspec(property(get = __get_CanvasContext)) ChatSectionContext* CanvasContext;
-  ;
 
 private:
+  friend class ObjectFinder<ChatMessageListLocalViewController>;
+
+public:
   static IL2CppClassHelper& get_class_helper()
   {
     static auto class_helper =
@@ -39,11 +42,15 @@ private:
     return class_helper;
   }
 
-public:
   TMP_InputField* __get__inputField()
   {
     static auto field = get_class_helper().GetField("_inputField").offset();
     return *(TMP_InputField**)((uintptr_t)this + field);
+  }
+  bool __get__inputFieldSelected()
+  {
+    static auto field = get_class_helper().GetField("_inputFieldSelected").offset();
+    return *(bool*)((uintptr_t)this + field);
   }
   ChatSectionContext* __get_CanvasContext()
   {

--- a/mods/src/prime/InputFieldWidget.h
+++ b/mods/src/prime/InputFieldWidget.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+#include "TMP_InputField.h"
+
+struct InputFieldWidget {
+public:
+  __declspec(property(get = __get__input)) TMP_InputField* _input;
+  __declspec(property(get = __get_isActiveAndEnabled)) bool isActiveAndEnabled;
+
+  void Focus()
+  {
+    static auto focusMethod = get_class_helper().GetMethod<void(InputFieldWidget*)>("Focus");
+    if (focusMethod) {
+      focusMethod(this);
+    }
+
+    // Fallback in case Focus method isn't present or doesn't activate properly
+    if (auto input = this->_input; input) {
+      input->ActivateInputField();
+    }
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "InputFieldWidget");
+    return class_helper;
+  }
+
+public:
+  TMP_InputField* __get__input()
+  {
+    static auto field = get_class_helper().GetField("_input").offset();
+    return *(TMP_InputField**)((uintptr_t)this + field);
+  }
+
+  bool __get_isActiveAndEnabled()
+  {
+    static auto field = get_class_helper().GetProperty("isActiveAndEnabled");
+    return field.Get<bool>(this);
+  }
+};

--- a/mods/src/prime/InventoryListViewController.h
+++ b/mods/src/prime/InventoryListViewController.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+#include "CanvasController.h"
+#include "Hub.h"
+#include "InputFieldWidget.h"
+
+struct InventoryListViewController {
+public:
+  __declspec(property(get = __get__inputField)) InputFieldWidget* _inputField;
+  __declspec(property(get = __get__targetSection)) SectionID       _targetSection;
+  __declspec(property(get = __get_isActiveAndEnabled)) bool        isActiveAndEnabled;
+  __declspec(property(get = __get_canvasController)) CanvasController* canvasController;
+
+private:
+  friend class ObjectFinder<InventoryListViewController>;
+
+public:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Inventories", "InventoryListViewController");
+    return class_helper;
+  }
+
+  InputFieldWidget* __get__inputField()
+  {
+    static auto field = get_class_helper().GetField("_inputField").offset();
+    return *(InputFieldWidget**)((uintptr_t)this + field);
+  }
+
+  SectionID __get__targetSection()
+  {
+    static auto field = get_class_helper().GetField("_targetSection").offset();
+    return *(SectionID*)((uintptr_t)this + field);
+  }
+
+  bool __get_isActiveAndEnabled()
+  {
+    static auto field = get_class_helper().GetProperty("isActiveAndEnabled");
+    return field.Get<bool>(this);
+  }
+
+  CanvasController* __get_canvasController()
+  {
+    return GetCanvasControllerFromComponent(this);
+  }
+};

--- a/mods/src/prime/OfficerAssignmentViewController.h
+++ b/mods/src/prime/OfficerAssignmentViewController.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+#include "CanvasController.h"
+#include "InputFieldWidget.h"
+
+struct OfficerAssignmentViewController {
+public:
+  __declspec(property(get = __get__inputField)) InputFieldWidget* _inputField;
+  __declspec(property(get = __get_isActiveAndEnabled)) bool        isActiveAndEnabled;
+  __declspec(property(get = __get_canvasController)) CanvasController* canvasController;
+
+private:
+  friend class ObjectFinder<OfficerAssignmentViewController>;
+
+public:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.OfficerAssignment", "OfficerAssignmentViewController");
+    return class_helper;
+  }
+
+  InputFieldWidget* __get__inputField()
+  {
+    static auto field = get_class_helper().GetField("_inputField").offset();
+    return *(InputFieldWidget**)((uintptr_t)this + field);
+  }
+
+  bool __get_isActiveAndEnabled()
+  {
+    static auto field = get_class_helper().GetProperty("isActiveAndEnabled");
+    return field.Get<bool>(this);
+  }
+
+  CanvasController* __get_canvasController()
+  {
+    return GetCanvasControllerFromComponent(this);
+  }
+};


### PR DESCRIPTION
## Summary

- **CTRL-F shortcut**: Adds a configurable hotkey (Ctrl+F) to focus search fields across inventory, officer, and ship assignment views
- **Null checks**: Adds comprehensive null safety checks across hotkeys, misc, object_tracker, testing, ui_scale, and zoom modules to prevent potential crashes

## Changes

### CTRL-F Search Focus
- New Focus_search patch with config toggle
- Prime headers for InputFieldWidget, InventoryListViewController, OfficerAssignmentViewController, AssignShipsWidget, CanvasController
- Hotkey integration in hotkeys.cc
- Object tracker integration for detecting active search contexts

### Null Safety Checks
- hotkeys.cc: Null checks before accessing game objects and UI elements
- misc.cc: Null guard additions
- object_tracker.cc: Null checks for tracked objects
- testing.cc: Safety additions
- ui_scale.cc: Null checks for transform and localScale
- zoom.cc: Null safety improvements