### PR TITLE
fix: coordinate search hotkey creates CoordinateSearchContext before navigation

### DIFF
--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -256,7 +256,14 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
         }
         return GotoSection(SectionID::Bookmarks_Main);
       } else if (MapKey::IsDown(GameFunction::ShowLookup)) {
-        return GotoSection(SectionID::Bookmarks_Search_Coordinates);
+        auto bookmark_manager = BookmarksManager::Instance();
+        if (bookmark_manager) {
+          bookmark_manager->ViewCoordinateSearch();
+          return;
+        }
+        spdlog::warn("[ShowLookup] BookmarksManager instance not available, falling back to main bookmarks");
+        GotoSection(SectionID::Bookmarks_Main);
+        return;
       } else if (MapKey::IsDown(GameFunction::ShowRefinery)) {
         return GotoSection(SectionID::Shop_Refining_List);
       } else if (MapKey::IsDown(GameFunction::ShowFactions)) {

--- a/mods/src/prime/BookmarksManager.h
+++ b/mods/src/prime/BookmarksManager.h
@@ -2,8 +2,10 @@
 
 #include "errormsg.h"
 #include <il2cpp/il2cpp_helper.h>
+#include <spdlog/spdlog.h>
 
 #include "MonoSingleton.h"
+#include "Hub.h"
 
 struct BookmarksManager : MonoSingleton<BookmarksManager> {
   friend struct MonoSingleton<BookmarksManager>;
@@ -22,7 +24,60 @@ public:
     }
   }
 
+  void ViewCoordinateSearch()
+  {
+    auto* context = CreateCoordinateSearchContext();
+    if (!context) {
+      spdlog::error("[CoordSearch] Failed to create CoordinateSearchContext, falling back to bookmarks");
+      ViewBookmarks();
+      return;
+    }
+
+    Hub::get_SectionManager()->TriggerSectionChange(SectionID::Bookmarks_Search_Coordinates, context, false, false, true);
+  }
+
 private:
+  void* CreateCoordinateSearchContext()
+  {
+    static auto coord_class = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Bookmarks", "CoordinateSearchContext");
+    if (!coord_class.isValidHelper()) {
+      spdlog::error("[CoordSearch] Failed to get CoordinateSearchContext class");
+      return nullptr;
+    }
+
+    auto* context = coord_class.New<void>();
+    if (!context) {
+      spdlog::error("[CoordSearch] Failed to create CoordinateSearchContext instance");
+      return nullptr;
+    }
+
+    static auto ctor_method = coord_class.GetMethod<void(void*)>(".ctor");
+    if (ctor_method) {
+      ctor_method(context);
+    } else {
+      spdlog::warn("[CoordSearch] CoordinateSearchContext .ctor() method not found");
+    }
+
+    auto* zero_str = il2cpp_string_new("0");
+    static auto set_x_method = coord_class.GetMethod<void(void*, void*)>("set_DefaultXCoordinate");
+    if (set_x_method && zero_str) {
+      set_x_method(context, zero_str);
+    }
+
+    static auto set_y_method = coord_class.GetMethod<void(void*, void*)>("set_DefaultYCoordinate");
+    if (set_y_method && zero_str) {
+      set_y_method(context, zero_str);
+    }
+
+    auto* empty_str = il2cpp_string_new("");
+    static auto set_system_method = coord_class.GetMethod<void(void*, void*)>("set_DefaultSystemInput");
+    if (set_system_method && empty_str) {
+      set_system_method(context, empty_str);
+    }
+
+    return context;
+  }
+
   static IL2CppClassHelper& get_class_helper()
   {
     static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Bookmarks", "BookmarksManager");


### PR DESCRIPTION
## Problem

The `ShowLookup` hotkey was calling `GotoSection(Bookmarks_Search_Coordinates)` with `nullptr` as `section_data`, causing the game to show a placeholder instead of the coordinate search screen.

## Root Cause

The native `BookmarksViewController.OnSearchCoorindatesButtonClicked()` creates and initializes a `CoordinateSearchContext` before triggering the section change. Without this context, the section system cannot display the coordinate search UI.

## Files Changed

- `mods/src/prime/BookmarksManager.h` — Added `ViewCoordinateSearch()` and private `CreateCoordinateSearchContext()`
- `mods/src/patches/parts/hotkeys.cc` — Updated `ShowLookup` hotkey to use `BookmarksManager::ViewCoordinateSearch()`

## Testing

Verified in-game: pressing the `ShowLookup` hotkey now correctly opens the coordinate search screen directly without needing to manually visit it first.
