### PR TITLE
fix: allow recall/repair when a viewer popup is open

### DIFF
--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -636,6 +636,10 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
   } else if (has_recall_cancel
              && (fleet->CurrentState == FleetState::WarpCharging || fleet->CurrentState == FleetState::Warping)) {
     fleet_controller->CancelButtonClicked();
+  } else if (has_recall && DidExecuteRecall(fleet_bar)) {
+    return;
+  } else if (has_repair && DidExecuteRepair(fleet_bar)) {
+    return;
   } else {
     auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
     for (auto pre_scan_widget : all_pre_scan_widgets) {
@@ -753,8 +757,10 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
                star_node_object_viewer_widget && star_node_object_viewer_widget->Context) {
       if (has_secondary) {
         star_node_object_viewer_widget->OnViewButtonActivation();
+        return;
       } else if (has_primary) {
         star_node_object_viewer_widget->InitiateWarp();
+        return;
       }
     } else if (auto navigation_ui_controller = ObjectFinder<NavigationInteractionUIViewController>::Get();
                navigation_ui_controller && has_primary) {
@@ -781,10 +787,6 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
         navigation_ui_controller->OnSetCourseButtonClick();
         return;
       }
-    } else if (has_recall && DidExecuteRecall(fleet_bar)) {
-      return;
-    } else if (has_repair && DidExecuteRepair(fleet_bar)) {
-      return;
     }
   }
 }


### PR DESCRIPTION
## Problem

When a viewer popup (mining node, star node, navigation interaction) was open on screen, pressing the recall key (R) did not recall the fleet. The same issue affected the repair key.

## Root Cause

In `ExecuteSpaceAction()`, recall and repair were in `else if` branches at the end of the viewer chain. If any viewer matched its `if` condition, the `else if` for recall was never reached -- even when the pressed key (R) didn't match any viewer action (which only check `has_primary`/`has_secondary`).

This was compounded by `force_space_action_next_frame` keeping `has_primary` true every frame, causing the nav controller block to intercept with `ValidateThenJoinArmada()` and log "have armada? Yes, State 0" repeatedly.

## Fix

- Keep recall/repair after the viewer chain to preserve the original multi-function key priority (Scan, then Recall, then Repair)
- Change recall/repair from `else if` to standalone `if` statements so they are reachable even when a viewer block was entered but did not handle the pressed key
- Reset `force_space_action_next_frame` when recall/repair fires, preventing the stuck retry flag from making `has_primary` true on every subsequent frame
- Add missing return statements to the star node viewer block (OnViewButtonActivation / InitiateWarp) to prevent fall-through when the action was already handled

## Priority order (after fix)

1. Queue clear
2. Warp cancel (if charging/warping)
3. Pre-scan widget actions (scan, engage, queue, armada)
4. Mining viewer actions (scan, mine)
5. Star node viewer actions (view, warp)
6. Nav controller actions (join armada, set course)
7. Recall -- standalone if, reachable even when viewer was open but did not handle the key
8. Repair -- standalone if, same as recall

The `disable_preview_recall` setting still works as before -- it gates the `has_recall` flag, so when enabled, recall is blocked while viewers are open.
