### PR TITLE
fix: preserve scan priority for recall/repair when viewer is open

### DIFF
--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -636,10 +636,6 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
   } else if (has_recall_cancel
              && (fleet->CurrentState == FleetState::WarpCharging || fleet->CurrentState == FleetState::Warping)) {
     fleet_controller->CancelButtonClicked();
-  } else if (has_recall && DidExecuteRecall(fleet_bar)) {
-    return;
-  } else if (has_repair && DidExecuteRepair(fleet_bar)) {
-    return;
   } else {
     auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
     for (auto pre_scan_widget : all_pre_scan_widgets) {
@@ -787,6 +783,15 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
         navigation_ui_controller->OnSetCourseButtonClick();
         return;
       }
+    }
+
+    if (has_recall && DidExecuteRecall(fleet_bar)) {
+      force_space_action_next_frame = false;
+      return;
+    }
+    if (has_repair && DidExecuteRepair(fleet_bar)) {
+      force_space_action_next_frame = false;
+      return;
     }
   }
 }


### PR DESCRIPTION
## Problem

PR #201 moved recall/repair checks before the viewer chain, which broke the original multi-function key priority. The same key was supposed to serve three functions in order: Scan, Repair, Recall -- depending on context. Moving recall/repair before the viewer chain meant recall would fire before scan was ever checked.

## Root Cause

The original bug was that recall/repair were `else if` branches at the end of the viewer chain -- unreachable when a viewer block matched its `if` condition but didn't handle the pressed key. 
This was compounded by `force_space_action_next_frame` keeping `has_primary` true every frame, causing the nav controller block to intercept with `ValidateThenJoinArmada()` (log showing: have armada? Yes, State 0).

## Fix

- Keep recall/repair after the viewer chain to preserve the original multi-function key priority (Scan, then Recall, then Repair)
- Change recall/repair from `else if` to standalone `if` statements so they are reachable even when a viewer block was entered but did not handle the pressed key
- Reset `force_space_action_next_frame` when recall/repair fires, preventing the stuck retry flag from making `has_primary` true on every subsequent frame

## Priority order (after fix)

1. Queue clear
2. Warp cancel (if charging/warping)
3. Pre-scan widget actions (scan, engage, queue, armada)
4. Mining viewer actions (scan, mine)
5. Star node viewer actions (view, warp)
6. Nav controller actions (join armada, set course)
7. Recall -- standalone if, reachable even when viewer was open but did not handle the key
8. Repair -- standalone if, same as recall

The `disable_preview_recall` setting still works as before -- it gates the `has_recall` flag, so when enabled, recall is blocked while viewers are open.
