### PR TITLE
Fix CT/FT equip UI refresh after slot changes

### DIFF
--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -2011,7 +2011,15 @@ void DataContainer_ParseEntitySlotsData(auto original, void* _this, EntityGroup*
   return original(_this, group);
 }
 
-void* RtcParser_ParseFinalPayload(auto original, void* _this, void* centrifugoInfo,
+// IL2CPP value type: keep this parameter by value so following arguments retain their platform ABI positions.
+struct CentrifugoInfo {
+  Il2CppString* Channel;
+  int32_t       Offset;
+};
+
+static_assert(sizeof(CentrifugoInfo) == 16);
+
+void* RtcParser_ParseFinalPayload(auto original, void* _this, CentrifugoInfo centrifugoInfo,
                                   RealtimeDataPayload* realtimeDataPayload, void* finalPayload)
 {
   if (realtimeDataPayload != nullptr && realtimeDataPayload->Target != nullptr


### PR DESCRIPTION
## Summary

- model `CentrifugoInfo` with its actual IL2CPP value-type layout
- pass the value by value through the slot RTC parser detour so following arguments retain their correct ABI positions
- add a compile-time size check to guard the expected 16-byte layout

## Root cause

The slot-sync hooks added for `SlotAssignRtcParser::ParseFinalPayload` and `SlotClearRtcParser::ParseFinalPayload` declared `CentrifugoInfo` as an 8-byte `void*`. The game declares it as a 16-byte value type containing a channel string pointer and an integer offset.

On ABIs that pass this aggregate in multiple registers, notably macOS ARM64, the incorrect declaration shifts the following realtime payload arguments. The server still accepts Chaos Tech and Forbidden Tech equipment changes, but the client can fail to process or notify the corresponding RTC slot update. The equipped tech therefore works in battle and appears after restart while the live UI remains stale.

This is a shared signature correctness fix rather than a macOS guard; runtime impact on other platforms has not yet been established.

## User impact

Chaos Tech and Forbidden Tech equip and unequip changes now appear immediately without restarting the game.

## Validation

- current July 20 IL2CPP research corpus confirms `CentrifugoInfo` is a 16-byte value type and both parser signatures take it by value
- `git diff --check`
- Windows release `xmake` build of `mods`
- [combined macOS test build](https://github.com/Guffawaffle/stfc-mod/actions/runs/29790403795) successfully installed and exercised with `syncpatches` enabled
- two macOS testers confirmed immediate CT equip/unequip UI updates; one had previously reproduced the stale-until-restart behavior

The linked runtime artifact also contained the independently reviewed macOS loading-transition fix. This PR itself contains only the RTC slot-parser ABI correction.