### PR TITLE
Fix CT/FT equip UI refresh after slot changes

### DIFF
--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -2292,7 +2292,15 @@ static void HandleEntityGroup(EntityGroup* entity_group)
 
 namespace hooks
 {
-static void* RtcParser_ParseFinalPayload(auto original, void* _this, void* centrifugoInfo,
+// IL2CPP value type: keep this parameter by value so following arguments retain their platform ABI positions.
+struct CentrifugoInfo {
+  Il2CppString* Channel;
+  int32_t       Offset;
+};
+
+static_assert(sizeof(CentrifugoInfo) == 16);
+
+static void* RtcParser_ParseFinalPayload(auto original, void* _this, CentrifugoInfo centrifugoInfo,
                                          RealtimeDataPayload* realtimeDataPayload, void* finalPayload)
 {
   if (realtimeDataPayload != nullptr && realtimeDataPayload->Target != nullptr


### PR DESCRIPTION
## Summary

- model `CentrifugoInfo` with its actual IL2CPP value-type layout
- pass the value by value through the consolidated RTC parser detour so following arguments retain their correct ABI positions
- add a compile-time size check to guard the expected 16-byte layout

## Root cause

PR #221 consolidated realtime slot processing behind `RtcParser::ParseFinalPayload` and removed the older slot-specific detours. That remaining hook still declared `CentrifugoInfo` as an 8-byte `void*`, while the game declares it as a 16-byte value type containing a channel string pointer and an integer offset.

On ABIs that pass this aggregate in multiple registers, notably macOS ARM64, the incorrect declaration shifts the following realtime payload arguments. This PR now applies the original ABI correction at the single parser seam retained by #221.

This is shared signature correctness rather than a macOS-only guard; runtime impact on other platforms has not been established.

## User impact

The corrected call boundary preserves live Chaos Tech and Forbidden Tech slot updates without retaining the legacy duplicate slot-parser hooks.

## Validation

- current IL2CPP research corpus confirms `CentrifugoInfo` is a 16-byte value type passed by value
- `git diff --check`
- Windows release `xmake` build of `mods`
- the pre-consolidation [combined macOS test build](https://github.com/Guffawaffle/stfc-mod/actions/runs/29790403795) successfully installed and exercised the same ABI correction with `syncpatches` enabled
- two macOS testers confirmed immediate CT equip/unequip UI updates in that build; one had previously reproduced the stale-until-restart behavior

The rebased PR contains only the value-type ABI correction on top of #221; its fresh GitHub Actions matrix provides the integration build coverage.