### PR TITLE
feat: cargo format hooks (configurable decimal precision)

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -229,6 +229,10 @@ loadingscreenhooks = true
 transitionscreenhooks = true
 focussearch = true
 
+# Set to true to override the number of decimal places shown for abbreviated cargo values
+# (e.g. 1.25M instead of 1M). When enabled, set cargo_significant_decimals in the [ui] section.
+cargoformathooks = false
+
 #  <[=========================================================================================================================================]>
 #
 #       *   *          *     *                                      *          ****  *                     *                    *
@@ -623,6 +627,10 @@ show_player_cargo = true
 
 # Set to true to always show the rewards for selected ships/stations
 show_station_cargo = true
+
+# Number of decimal places to show for abbreviated cargo values when cargoformathooks is enabled.
+# Examples: 0 = 1M, 1 = 1.2M, 2 = 1.25M, 3 = 1.250M
+cargo_significant_decimals = 2
 
 # Subgroup: Unsupported
 # ---------------------

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -658,6 +658,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "patches", "giftsbulkclaimhooks", DCP::giftsbulkclaimhooks, write_config);
   this->installFocusSearchHooks =
       get_config_or_default(config, parsed, "patches", "focussearch", DCP::focussearch, write_config);
+  this->installCargoFormatHooks =
+      get_config_or_default(config, parsed, "patches", "cargoformathooks", DCP::cargoformathooks, write_config);
   spdlog::debug("");
 
   this->queue_enabled =
@@ -764,6 +766,9 @@ void Config::Load()
       get_config_or_default(config, parsed, "ui", "show_hostile_cargo", DCU::show_hostile_cargo, write_config);
   this->show_armada_cargo =
       get_config_or_default(config, parsed, "ui", "show_armada_cargo", DCU::show_armada_cargo, write_config);
+
+  this->cargo_significant_decimals =
+      get_config_or_default(config, parsed, "ui", "cargo_significant_decimals", DCU::cargo_significant_decimals, write_config);
 
   this->always_skip_reveal_sequence = get_config_or_default(config, parsed, "ui", "always_skip_reveal_sequence",
                                                             DCU::always_skip_reveal_sequence, write_config);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -221,4 +221,8 @@ public:
   bool installLoadingScreenHooks;
   bool installTransitionScreenHooks;
   bool installFocusSearchHooks;
+
+  // Cargo formatting
+  bool installCargoFormatHooks;
+  int  cargo_significant_decimals;
 };

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -78,6 +78,7 @@ namespace Patches
   constexpr bool miscpatches                = true;
   constexpr bool giftsbulkclaimhooks        = true;
   constexpr bool focussearch                = true;
+  constexpr bool cargoformathooks           = false; // opt-in: changes cargo number precision
 } // namespace Patches
 
 namespace Shortcuts
@@ -221,6 +222,7 @@ namespace UI
   constexpr bool        show_hostile_cargo          = true;
   constexpr bool        show_player_cargo           = true;
   constexpr bool        show_station_cargo          = true;
+  constexpr int         cargo_significant_decimals  = 2; // decimal places for abbreviated cargo values (e.g. 1.25M)
 } // namespace UI
 
 } // namespace DefaultConfig

--- a/mods/src/patches/parts/cargo_format.cc
+++ b/mods/src/patches/parts/cargo_format.cc
@@ -6,19 +6,25 @@
 #include <spdlog/spdlog.h>
 #include <spud/detour.h>
 
-#include <str_utils.h>
-
-// Field offsets on TextLocalizer (from IL2CPP dump):
-//   m_identifier          (string, GraphicLocalizer base) — resolved via field API
-//   m_significantDecimals (int)    offset 0x70
-//   m_abbreviateNumbers   (bool)   offset 0x6C
-//   m_truncateDecimals    (bool)   offset 0x6D
+// Cargo display uses a ColourTextLocalizer (Digit.Client.UI.ColourTextLocalizer)
+// with identifier "shared_x_of_y_x_coloured". Number formatting is controlled by
+// the m_significantDecimals field on the TextLocalizer base class
+// (Digit.Client.UI.TextLocalizer). Fields are resolved at runtime via the field
+// API — no hardcoded offsets are used.
 //
-// The cargo display uses a ColourTextLocalizer with identifier "shared_x_of_y_x_coloured".
-// We hook SetLocalTextParameters to temporarily override m_significantDecimals before
-// the original method formats the number, then restore it afterwards.
+// We hook ColourTextLocalizer.SetLocalTextParameters to temporarily override
+// m_significantDecimals for cargo localizers only, then restore it via an RAII
+// guard so the field is always restored even if the original throws.
 
-static const char* kCargoIdentifier = "shared_x_of_y_x_coloured";
+static constexpr char  kCargoIdentifier[]    = "shared_x_of_y_x_coloured";
+static constexpr size_t kCargoIdentifierLen  = sizeof(kCargoIdentifier) - 1; // exclude trailing '\0'
+
+// RAII guard that restores an int field on destruction — exception-safe.
+struct FieldRestore {
+  int* ptr;
+  int  saved;
+  ~FieldRestore() { if (ptr) *ptr = saved; }
+};
 
 void ColourTextLocalizer_SetLocalTextParameters_Hook(auto original, void* _this, bool parseID, void* args)
 {
@@ -27,13 +33,13 @@ void ColourTextLocalizer_SetLocalTextParameters_Hook(auto original, void* _this,
     return;
   }
 
-  const auto desired_decimals = Config::Get().cargo_significant_decimals;
-  if (desired_decimals < 0) {
-    original(_this, parseID, args);
-    return;
-  }
+  // Clamp user config to a safe range. Negative values are treated as 0
+  // (no decimals); values above 6 are capped to avoid absurd formatting.
+  int desired_decimals = Config::Get().cargo_significant_decimals;
+  if (desired_decimals < 0) desired_decimals = 0;
+  if (desired_decimals > 6) desired_decimals = 6;
 
-  // Resolve the m_identifier field from the GraphicLocalizer base class
+  // Resolve fields from the TextLocalizer base class (resolved once, cached).
   static auto text_localizer_h =
       il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "TextLocalizer");
   static auto identifier_field = text_localizer_h.GetField("m_identifier");
@@ -44,30 +50,43 @@ void ColourTextLocalizer_SetLocalTextParameters_Hook(auto original, void* _this,
     return;
   }
 
-  // Read the identifier string
+  // Read the identifier string pointer.
   auto* identifier_ptr = *reinterpret_cast<Il2CppString**>((char*)_this + identifier_field.offset());
   if (!identifier_ptr) {
     original(_this, parseID, args);
     return;
   }
 
-  auto identifier = to_string(identifier_ptr);
-  if (identifier != kCargoIdentifier) {
+  // Fast path: compare length first, then raw UTF-16 chars (the identifier is
+  // ASCII, so each Il2CppChar fits in the low byte). This avoids allocating a
+  // std::string via to_string on every call — SetLocalTextParameters fires for
+  // every ColourTextLocalizer in the UI, not just cargo.
+  if ((size_t)identifier_ptr->length != kCargoIdentifierLen) {
+    original(_this, parseID, args);
+    return;
+  }
+  const Il2CppChar* chars = identifier_ptr->chars;
+  for (size_t i = 0; i < kCargoIdentifierLen; ++i) {
+    if ((char)chars[i] != kCargoIdentifier[i]) {
+      original(_this, parseID, args);
+      return;
+    }
+  }
+
+  // Identifier matches — override m_significantDecimals for this call only.
+  auto* sig_decimals_ptr = reinterpret_cast<int*>((char*)_this + sig_decimals_field.offset());
+  int   original_decimals = *sig_decimals_ptr;
+
+  if (original_decimals == desired_decimals) {
     original(_this, parseID, args);
     return;
   }
 
-  // Save and override m_significantDecimals
-  auto* sig_decimals_ptr = reinterpret_cast<int*>((char*)_this + sig_decimals_field.offset());
-  int  original_decimals = *sig_decimals_ptr;
-
-  if (original_decimals != desired_decimals) {
-    *sig_decimals_ptr = desired_decimals;
-    original(_this, parseID, args);
-    *sig_decimals_ptr = original_decimals;
-  } else {
-    original(_this, parseID, args);
-  }
+  *sig_decimals_ptr = desired_decimals;
+  // RAII restore — runs even if original() throws a managed exception that
+  // unwinds the stack, so the localizer is never left in a corrupted state.
+  FieldRestore guard{sig_decimals_ptr, original_decimals};
+  original(_this, parseID, args);
 }
 
 void InstallCargoFormatHooks()

--- a/mods/src/patches/parts/cargo_format.cc
+++ b/mods/src/patches/parts/cargo_format.cc
@@ -1,0 +1,90 @@
+#include "config.h"
+#include "errormsg.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+#include <spdlog/spdlog.h>
+#include <spud/detour.h>
+
+#include <str_utils.h>
+
+// Field offsets on TextLocalizer (from IL2CPP dump):
+//   m_identifier          (string, GraphicLocalizer base) — resolved via field API
+//   m_significantDecimals (int)    offset 0x70
+//   m_abbreviateNumbers   (bool)   offset 0x6C
+//   m_truncateDecimals    (bool)   offset 0x6D
+//
+// The cargo display uses a ColourTextLocalizer with identifier "shared_x_of_y_x_coloured".
+// We hook SetLocalTextParameters to temporarily override m_significantDecimals before
+// the original method formats the number, then restore it afterwards.
+
+static const char* kCargoIdentifier = "shared_x_of_y_x_coloured";
+
+void ColourTextLocalizer_SetLocalTextParameters_Hook(auto original, void* _this, bool parseID, void* args)
+{
+  if (!_this) {
+    original(_this, parseID, args);
+    return;
+  }
+
+  const auto desired_decimals = Config::Get().cargo_significant_decimals;
+  if (desired_decimals < 0) {
+    original(_this, parseID, args);
+    return;
+  }
+
+  // Resolve the m_identifier field from the GraphicLocalizer base class
+  static auto text_localizer_h =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "TextLocalizer");
+  static auto identifier_field = text_localizer_h.GetField("m_identifier");
+  static auto sig_decimals_field = text_localizer_h.GetField("m_significantDecimals");
+
+  if (!identifier_field.isValidHelper() || !sig_decimals_field.isValidHelper()) {
+    original(_this, parseID, args);
+    return;
+  }
+
+  // Read the identifier string
+  auto* identifier_ptr = *reinterpret_cast<Il2CppString**>((char*)_this + identifier_field.offset());
+  if (!identifier_ptr) {
+    original(_this, parseID, args);
+    return;
+  }
+
+  auto identifier = to_string(identifier_ptr);
+  if (identifier != kCargoIdentifier) {
+    original(_this, parseID, args);
+    return;
+  }
+
+  // Save and override m_significantDecimals
+  auto* sig_decimals_ptr = reinterpret_cast<int*>((char*)_this + sig_decimals_field.offset());
+  int  original_decimals = *sig_decimals_ptr;
+
+  if (original_decimals != desired_decimals) {
+    *sig_decimals_ptr = desired_decimals;
+    original(_this, parseID, args);
+    *sig_decimals_ptr = original_decimals;
+  } else {
+    original(_this, parseID, args);
+  }
+}
+
+void InstallCargoFormatHooks()
+{
+  auto colour_text_localizer_h =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "ColourTextLocalizer");
+  if (!colour_text_localizer_h.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Client.UI", "ColourTextLocalizer");
+    return;
+  }
+
+  auto ptr = colour_text_localizer_h.GetMethod("SetLocalTextParameters");
+  if (!ptr) {
+    ErrorMsg::MissingMethod("ColourTextLocalizer", "SetLocalTextParameters");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(ptr, ColourTextLocalizer_SetLocalTextParameters_Hook);
+  spdlog::info("Cargo format: significant decimals = {}", Config::Get().cargo_significant_decimals);
+}

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -40,6 +40,7 @@ void InstallLoadingScreenHooks();
 void InstallTransitionScreenHooks();
 void InstallLoadingTipHooks();
 void InstallFocusSearchHooks();
+void InstallCargoFormatHooks();
 
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
 {
@@ -126,6 +127,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"TransitionScreen",     {InstallTransitionScreenHooks, &cfg.installTransitionScreenHooks}},
       {"LoadingTip",           {InstallLoadingTipHooks,       &cfg.loader_tip_enabled}},
       {"FocusSearch",          {InstallFocusSearchHooks,      &cfg.installFocusSearchHooks}},
+      {"CargoFormat",          {InstallCargoFormatHooks,      &cfg.installCargoFormatHooks}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);
 


### PR DESCRIPTION
## Summary

- Adds a new opt-in patch (`cargoformathooks`, default `false`) that overrides the number of decimal places shown for abbreviated cargo values in the game UI (e.g. `1.25M` instead of `1M`).
- Hooks `ColourTextLocalizer.SetLocalTextParameters` and temporarily overrides `TextLocalizer.m_significantDecimals` for cargo displays only (identifier `shared_x_of_y_x_coloured`), restoring the original value afterwards via an RAII guard.
- New config settings: `cargoformathooks` (under `[patches]`) and `cargo_significant_decimals` (under `[ui]`, default `2`).

### Safety hardening

- **RAII exception safety** — `FieldRestore` guard restores `m_significantDecimals` even if the original method throws a managed exception that unwinds the stack, preventing permanent localizer corruption.
- **Config clamping** — `cargo_significant_decimals` is clamped to `[0, 6]`; negatives become `0`, values above `6` become `6`. No silent disable sentinel.
- **Fast-path identifier check** — compares `Il2CppString::length` first, then raw UTF-16 chars directly, avoiding a `to_string` allocation on every `ColourTextLocalizer` call (the hook fires for all of them, not just cargo).
- **Compile-time length** — `kCargoIdentifierLen` derived via `sizeof(...) - 1` so it can never drift from the string literal.
- Fields resolved dynamically via the IL2CPP field API — no hardcoded offsets.

#### Test plan

- [x] Builds clean on Windows x64 release (`xmake f -p windows -m release && xmake -y stfc-community-mod`)
- [x] Class hierarchy verified against game dump (`ColourTextLocalizer : TextLocalizer : GraphicLocalizer`)
- [x] `SetLocalTextParameters(bool, object[])` signature matches dump
- [x] Deployed and tested in-game — cargo values display with configured decimal precision
- [ ] Verify with `cargo_significant_decimals = 0` (should show `1M`)
- [ ] Verify with `cargo_significant_decimals = 3` (should show `1.250M`)
- [ ] Verify non-cargo `ColourTextLocalizer` instances are unaffected

Generated with [Devin](https://devin.ai)
