### PR TITLE
fix: restore unlimited donation slider

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -594,7 +594,7 @@ disable_veil_chat = false
 # Subgroup: Donations
 # -------------------
 
-# Extend donation slider to max value for next Alliance level
+# Extend donation slider to max value for next Alliance level; set to 0 for unlimited
 extend_donation_max = 80
 
 # Extend donation slider enable

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -30,6 +30,9 @@ void InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, i
     const auto max = Config::Get().extend_donation_max;
     if (max > 0) {
       a2 = max;
+    } else {
+      // Leave the initial unlimited value in place instead of applying the game's donation cap.
+      return;
     }
   }
 


### PR DESCRIPTION
## Summary

- restore `extend_donation_max = 0` as the unlimited donation-slider setting
- document the zero-value behavior in the example configuration

## User impact

Players can once again enable `extend_donation_slider` and set `extend_donation_max = 0` to donate without the artificial slider limit.

## Validation

- confirmed working in the live game client with multi-million contribution values
- Windows release `mods` target built successfully
- full Windows release DLL linked successfully
- `git diff --check` passes

This PR intentionally excludes the unrelated generated-image and XMake changes.
