### PR TITLE
Fix stale NavigationZoom camera access

### DIFF
--- a/mods/src/patches/parts/zoom.cc
+++ b/mods/src/patches/parts/zoom.cc
@@ -44,7 +44,6 @@ inline void StoreZoom(std::string label, float &zoom, NavigationZoom *_this)
 
 static float           s_expectedScale = 0;
 static void           *s_cachedFR      = nullptr;
-static NavigationZoom *s_navZoom       = nullptr;
 
 static void ApplySystemZoomRange(NavigationZoom *_this, float radius)
 {
@@ -55,7 +54,6 @@ static void ApplySystemZoomRange(NavigationZoom *_this, float radius)
   auto ratio                     = (Config::Get().zoom / radius);
   _this->_farRatioSystemNormal   = 0.55f * ratio;
   _this->_farRatioSystemExtended = ratio;
-  s_navZoom                      = _this;
 }
 
 static void SetSceneCameraFarClip(NavigationZoom *_this)
@@ -246,18 +244,6 @@ void PlanetViewUtils_CameraZoomedEventHandler_Hook(auto original, PlanetViewUtil
 
   _this->GetFlatRenderable(); // probe: triggers get_FlatRenderable_Hook, which scales the FR; game often reads the
                               // field directly so our detour needs this call-path
-
-  if (s_navZoom) {
-    auto *cam = s_navZoom->_sceneCamera;
-    if (cam) {
-      int cf = cam->clearFlags;
-      if (cf >= 0 && cf <= 4 && cf != 2) {
-        cam->farClipPlane    = Config::Get().zoom * 3.75f;
-        cam->clearFlags      = 2;
-        cam->backgroundColor = {0, 0, 0, 0};
-      }
-    }
-  }
 }
 
 void NavigationZoom_SetViewParameters_Hook(auto original, NavigationZoom *_this, float radius, NodeDepth depth)


### PR DESCRIPTION
## Problem

The extended zoom patch retained a `NavigationZoom` instance in `s_navZoom` and reused it from `PlanetViewUtils_CameraZoomedEventHandler_Hook`. That callback can run after a view change, when the cached instance and its scene camera belong to the previous view. Reading `clearFlags` through that stale camera caused an `EXC_BAD_ACCESS`.

## Fix

Remove the cached `NavigationZoom` instance and the callback block that uses it. Camera far-clip configuration already runs from live `NavigationZoom` instances in the view-parameter and depth hooks, so the removed update was redundant.

This keeps camera access tied to the lifetime of the owning view and does not change extended zoom behavior.