### PR TITLE
fix: avoid stale zoom scene pointers

### DIFF
--- a/mods/src/patches/parts/zoom.cc
+++ b/mods/src/patches/parts/zoom.cc
@@ -42,9 +42,7 @@ inline void StoreZoom(std::string label, float &zoom, NavigationZoom *_this)
   spdlog::info("Changing {} from {} to {}", label, old_zoom, zoom);
 }
 
-static float           s_expectedScale = 0;
-static void           *s_cachedFR      = nullptr;
-static NavigationZoom *s_navZoom       = nullptr;
+static float s_expectedScale = 0;
 
 static void ApplySystemZoomRange(NavigationZoom *_this, float radius)
 {
@@ -55,7 +53,6 @@ static void ApplySystemZoomRange(NavigationZoom *_this, float radius)
   auto ratio                     = (Config::Get().zoom / radius);
   _this->_farRatioSystemNormal   = 0.55f * ratio;
   _this->_farRatioSystemExtended = ratio;
-  s_navZoom                      = _this;
 }
 
 static void SetSceneCameraFarClip(NavigationZoom *_this)
@@ -244,19 +241,9 @@ void PlanetViewUtils_CameraZoomedEventHandler_Hook(auto original, PlanetViewUtil
 {
   original(_this, zoomDistance, normalizedZoom);
 
-  _this->GetFlatRenderable(); // probe: triggers get_FlatRenderable_Hook, which scales the FR; game often reads the
-                              // field directly so our detour needs this call-path
-
-  if (s_navZoom) {
-    auto *cam = s_navZoom->_sceneCamera;
-    if (cam) {
-      int cf = cam->clearFlags;
-      if (cf >= 0 && cf <= 4 && cf != 2) {
-        cam->farClipPlane    = Config::Get().zoom * 3.75f;
-        cam->clearFlags      = 2;
-        cam->backgroundColor = {0, 0, 0, 0};
-      }
-    }
+  if (_this != nullptr) {
+    _this->GetFlatRenderable(); // probe: triggers get_FlatRenderable_Hook, which scales the FR; game often reads the
+                                // field directly so our detour needs this call-path
   }
 }
 
@@ -285,10 +272,6 @@ void NavigationZoom_SetDepth_Hook(auto original, NavigationZoom *_this, NodeDept
 
     SetSceneCameraFarClip(_this);
     do_default_zoom = true;
-
-    if (s_cachedFR) {
-      ScaleFR(s_cachedFR);
-    }
   } else {
     original(_this, depth);
   }
@@ -301,7 +284,6 @@ void *PlanetViewUtils_get_FlatRenderable_Hook(auto original, PlanetViewUtils *_t
     return fr;
   }
 
-  s_cachedFR = fr;
   ScaleFR(fr);
   return fr;
 }


### PR DESCRIPTION
## Summary

- remove the process-lifetime `NavigationZoom` and flat-renderable caches from the zoom patch
- run the original camera-zoom handler first, then use the current `PlanetViewUtils` accessor to scale the current scene's backdrop
- stop rescaling a cached flat renderable during depth changes while preserving the existing anti-double-scaling behavior

## Evidence and root cause

This is an evidence-based correction for a captured `0xc0000005` access violation in `VERSION.dll`. The resolved Unity stack points directly to `PlanetViewUtils_CameraZoomedEventHandler_Hook`, with the fault occurring while reading `s_navZoom->_sceneCamera->clearFlags` after a server transfer and first system view.

The cached `NavigationZoom` and flat-renderable pointers are scene-owned IL2CPP/Unity objects, but the caches have process lifetime. After a navigation-scene replacement, a cached pointer can remain non-null while referring to a destroyed object, so null checks do not provide lifetime safety.

The hook now performs backdrop scaling through the current non-null `PlanetViewUtils` instance and no longer dereferences previously cached scene objects.

## Validation

- `xmake f -p windows -a x64 -m release -y`
- `xmake -y mods`
- `git diff --check`

The Windows x64 release `mods` target builds successfully.

## Runtime testing needed

This fix has not yet been runtime-tested. It should remain a draft until someone can validate it in Arenas, including the first system view after the relevant scene/server transition. The original captured reproduction was a server transfer during Incursions followed by viewing a system for the first time.
