### PR TITLE
fix: null-check Camera property getters to prevent a zoom-time crash

### DIFF
--- a/mods/src/prime/Camera.h
+++ b/mods/src/prime/Camera.h
@@ -21,7 +21,8 @@ public:
   float __get_farClipPlane()
   {
     static auto field = get_class_helper().GetProperty("farClipPlane");
-    return *field.GetRaw<float>(this);
+    auto*       ptr   = field.GetRaw<float>(this);
+    return ptr ? *ptr : 0.0f;
   }
   void __set_farClipPlane(float v)
   {
@@ -32,7 +33,8 @@ public:
   float __get_nearClipPlane()
   {
     static auto field = get_class_helper().GetProperty("nearClipPlane");
-    return *field.GetRaw<float>(this);
+    auto*       ptr   = field.GetRaw<float>(this);
+    return ptr ? *ptr : 0.0f;
   }
   void __set_nearClipPlane(float v)
   {
@@ -43,7 +45,8 @@ public:
   int __get_clearFlags()
   {
     static auto field = get_class_helper().GetProperty("clearFlags");
-    return *field.GetRaw<int>(this);
+    auto*       ptr   = field.GetRaw<int>(this);
+    return ptr ? *ptr : 0;
   }
   void __set_clearFlags(int v)
   {


### PR DESCRIPTION
Camera::__get_clearFlags / __get_farClipPlane / __get_nearClipPlane dereferenced GetRaw()'s result without a null check, unlike __get_backgroundColor which guards it.  If the scene camera is stale and a zoom/view-change event fires during load or just after a (re)login the cached NavigationZoom's _sceneCamera resolves to a dead object- the property getter returns null and `*ptr` faults.

Traced from a minidump crash :  bt is in PlanetViewUtils_CameraZoomedEventHandler_Hook reading cam->clearFlags, reached via NavigationZoom.ReportZoomChange on a view change.  So, guard the three getters the same way backgroundColor already does.  The setters use SetRaw (invoke-and-ignore), and seemingly already stale-safe.