### PR TITLE
ci: optimize build caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,8 @@ name: Build
 on:
   push:
     branches:
-      - "**"
+      - "main"
+      - "dev"
   pull_request:
     branches: ["main", "dev"]
 
@@ -18,7 +19,13 @@ concurrency:
 env:
   XMAKE_VERSION: "3.1.0"
   # Bump this when a dependency cache must be invalidated manually.
-  XMAKE_CACHE_SCHEMA: "v3"
+  XMAKE_CACHE_SCHEMA: "v4"
+  # Narrow protobuf-only compiler-cache experiment.
+  PROTOBUF_SCCACHE_VERSION: "v0.17.0"
+  PROTOBUF_SCCACHE_SCHEMA: "v1"
+  STFC_PROTOBUF_SCCACHE: "1"
+  # Keep sccache local; actions/cache owns persistence explicitly.
+  SCCACHE_GHA_ENABLED: "false"
   # setup-xmake normally exports this when its integrated build cache is on.
   # Keep XMake's compiler cache enabled while managing persistence ourselves.
   XMAKE_ACTION_BUILD_CACHE: "true"
@@ -26,6 +33,9 @@ env:
 jobs:
   build-win:
     runs-on: windows-2025-vs2026
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}/build/.protobuf-sccache
+      SCCACHE_CACHE_SIZE: "1G"
 
     steps:
       - name: Checkout
@@ -50,6 +60,23 @@ jobs:
         with:
           xmake-version: ${{ env.XMAKE_VERSION }}
 
+      - name: Setup protobuf sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: ${{ env.PROTOBUF_SCCACHE_VERSION }}
+
+      - name: Identify Windows runner image
+        id: windows_toolchain
+        shell: pwsh
+        run: |
+          if (-not $env:ImageVersion) { throw "GitHub runner ImageVersion is unavailable" }
+          "image_version=$env:ImageVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Set protobuf compiler cache identity
+        shell: pwsh
+        run: |
+          "SCCACHE_C_CUSTOM_CACHE_BUSTER=stfc-protobuf-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-xmake-${{ env.XMAKE_VERSION }}-windows-x64-release-${{ hashFiles('mods/src/prime/proto/*.proto', 'mods/xmake.lua', 'xmake.lua', 'xmake-requires.lock', 'xmake/dependencies/common.lua', 'xmake/dependencies/windows.lua', 'xmake/rules/protobuf_sccache.lua') }}" >> $env:GITHUB_ENV
+
       - name: Locate XMake caches
         id: xmake_cache_paths
         shell: pwsh
@@ -70,10 +97,27 @@ jobs:
           path: ${{ steps.xmake_cache_paths.outputs.package_dir }}
           key: windows-x64-release-xmake-${{ env.XMAKE_VERSION }}-${{ env.XMAKE_CACHE_SCHEMA }}-${{ hashFiles('xmake/dependencies/common.lua', 'xmake/dependencies/windows.lua', 'xmake-requires.lock', 'xmake-packages/**') }}
 
+      - name: Restore XMake local packages
+        id: restore_local_packages
+        uses: actions/cache/restore@v6
+        with:
+          path: build/.packages
+          key: windows-x64-release-xmake-local-${{ env.XMAKE_VERSION }}-${{ env.XMAKE_CACHE_SCHEMA }}-${{ hashFiles('xmake/dependencies/common.lua', 'xmake/dependencies/windows.lua', 'xmake-requires.lock', 'xmake-packages/packages/s/spud/**') }}
+
+      - name: Restore protobuf compiler cache
+        id: restore_protobuf_sccache
+        uses: actions/cache/restore@v6
+        with:
+          path: build/.protobuf-sccache
+          key: windows-x64-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-${{ steps.windows_toolchain.outputs.image_version }}-${{ github.sha }}
+          restore-keys: |
+            windows-x64-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-${{ steps.windows_toolchain.outputs.image_version }}-
+            windows-x64-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-
+
       - name: Configure
         id: configure_windows
         timeout-minutes: 30
-        run: xmake f -m release -y
+        run: xmake f -m release -y -v
 
       - name: Verify dependency lock
         shell: pwsh
@@ -108,8 +152,16 @@ jobs:
           include-hidden-files: true
           retention-days: 3
 
+      - name: Reset protobuf compiler cache stats
+        shell: pwsh
+        run: sccache --zero-stats
+
       - name: Build
         run: xmake build -y stfc-community-mod
+
+      - name: Report protobuf compiler cache
+        shell: pwsh
+        run: sccache --show-stats
 
       - name: Package
         shell: pwsh
@@ -132,6 +184,20 @@ jobs:
         with:
           path: ${{ steps.xmake_cache_paths.outputs.package_dir }}
           key: ${{ steps.restore_packages.outputs.cache-primary-key }}
+
+      - name: Save XMake local packages
+        if: ${{ success() && !cancelled() && steps.restore_local_packages.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: build/.packages
+          key: ${{ steps.restore_local_packages.outputs.cache-primary-key }}
+
+      - name: Save protobuf compiler cache
+        if: ${{ success() && !cancelled() && steps.restore_protobuf_sccache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: build/.protobuf-sccache
+          key: ${{ steps.restore_protobuf_sccache.outputs.cache-primary-key }}
 
       - name: Save XMake
         if: ${{ success() && !cancelled() && steps.restore_xmake.outputs.cache-hit != 'true' }}
@@ -156,6 +222,11 @@ jobs:
             artifact: macos-x86_64-build
 
     runs-on: ${{ matrix.runner }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "13.5"
+      SWIFT_MODULE_CACHE_SCHEMA: "v1"
+      SCCACHE_DIR: ${{ github.workspace }}/build/.protobuf-sccache
+      SCCACHE_CACHE_SIZE: "1G"
 
     steps:
       - name: Checkout
@@ -180,6 +251,16 @@ jobs:
         with:
           xmake-version: ${{ env.XMAKE_VERSION }}
 
+      - name: Setup protobuf sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: ${{ env.PROTOBUF_SCCACHE_VERSION }}
+
+      - name: Set protobuf compiler cache identity
+        shell: bash
+        run: |
+          echo "SCCACHE_C_CUSTOM_CACHE_BUSTER=stfc-protobuf-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-xmake-${{ env.XMAKE_VERSION }}-macos-${{ matrix.arch }}-release-${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('mods/src/prime/proto/*.proto', 'mods/xmake.lua', 'xmake.lua', 'xmake-requires.lock', 'xmake/dependencies/common.lua', 'xmake/dependencies/macos.lua', 'xmake/rules/protobuf_sccache.lua') }}" >> "$GITHUB_ENV"
+
       - name: Locate XMake caches
         id: xmake_cache_paths
         shell: bash
@@ -188,25 +269,67 @@ jobs:
 
           PACKAGE_DIR="$(xmake l -c 'import("core.package.package"); print(package.installdir())')"
           test -n "$PACKAGE_DIR"
+          PLZMA_SHA="$(git -C macos-launcher/deps/PLzmaSDK rev-parse HEAD)"
+          test -n "$PLZMA_SHA"
 
           echo "package_dir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
-          echo "utc_day=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+          echo "plzma_sha=$PLZMA_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Identify Swift toolchain
+        id: swift_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          {
+            xcodebuild -version
+            xcrun swiftc --version
+            xcrun --sdk macosx --show-sdk-version
+          } | tee "$RUNNER_TEMP/swift-toolchain.txt"
+
+          TOOLCHAIN_HASH="$(shasum -a 256 "$RUNNER_TEMP/swift-toolchain.txt" | awk '{print $1}')"
+          test -n "$TOOLCHAIN_HASH"
+          echo "hash=$TOOLCHAIN_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Restore XMake packages
         id: restore_packages
         uses: actions/cache/restore@v6
         with:
           path: ${{ steps.xmake_cache_paths.outputs.package_dir }}
-          key: macos-${{ matrix.arch }}-release-xmake-${{ env.XMAKE_VERSION }}-${{ env.XMAKE_CACHE_SCHEMA }}-${{ hashFiles('xmake/dependencies/common.lua', 'xmake/dependencies/macos.lua', 'xmake-requires.lock', 'xmake-packages/**') }}
+          key: macos-${{ matrix.arch }}-release-xmake-${{ env.XMAKE_VERSION }}-${{ env.XMAKE_CACHE_SCHEMA }}-${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ steps.xmake_cache_paths.outputs.plzma_sha }}-${{ hashFiles('xmake/dependencies/common.lua', 'xmake/dependencies/macos.lua', 'xmake-requires.lock', 'xmake-packages/**') }}
+
+      - name: Restore XMake local packages
+        id: restore_local_packages
+        uses: actions/cache/restore@v6
+        with:
+          path: build/.packages
+          key: macos-${{ matrix.arch }}-release-xmake-local-${{ env.XMAKE_VERSION }}-${{ env.XMAKE_CACHE_SCHEMA }}-${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ steps.xmake_cache_paths.outputs.plzma_sha }}-${{ hashFiles('xmake/dependencies/common.lua', 'xmake/dependencies/macos.lua', 'xmake-requires.lock', 'xmake-packages/packages/s/spud/**', 'xmake-packages/packages/p/PLzmaSDK/**') }}
+
+      - name: Restore Swift module cache
+        id: restore_swift_modules
+        uses: actions/cache/restore@v6
+        with:
+          path: build/.swift-module-cache
+          key: macos-${{ matrix.arch }}-release-swift-modules-${{ env.SWIFT_MODULE_CACHE_SCHEMA }}-${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ steps.swift_toolchain.outputs.hash }}-${{ steps.xmake_cache_paths.outputs.plzma_sha }}-${{ hashFiles('macos-launcher/xmake.lua', 'macos-launcher/src/module.modulemap', 'xmake/dependencies/macos.lua', 'xmake-requires.lock', 'xmake-packages/packages/p/PLzmaSDK/**') }}
 
       - name: Restore XMake compiler cache
         id: restore_build
         uses: actions/cache/restore@v6
         with:
           path: build/.build_cache
-          key: macos-${{ matrix.arch }}-release-${{ env.XMAKE_CACHE_SCHEMA }}-${{ steps.xmake_cache_paths.outputs.utc_day }}
+          key: macos-${{ matrix.arch }}-release-${{ env.XMAKE_CACHE_SCHEMA }}-${{ github.sha }}
           restore-keys: |
             macos-${{ matrix.arch }}-release-${{ env.XMAKE_CACHE_SCHEMA }}-
+
+      - name: Restore protobuf compiler cache
+        id: restore_protobuf_sccache
+        uses: actions/cache/restore@v6
+        with:
+          path: build/.protobuf-sccache
+          key: macos-${{ matrix.arch }}-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-${{ steps.swift_toolchain.outputs.hash }}-${{ github.sha }}
+          restore-keys: |
+            macos-${{ matrix.arch }}-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-${{ steps.swift_toolchain.outputs.hash }}-
+            macos-${{ matrix.arch }}-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-
 
       - name: Configure
         id: configure
@@ -217,7 +340,8 @@ jobs:
           -a "${{ matrix.arch }}"
           -m release
           -y
-          --target_minver=13.5
+          -v
+          --target_minver="$MACOSX_DEPLOYMENT_TARGET"
 
       - name: Verify dependency lock
         shell: bash
@@ -241,8 +365,29 @@ jobs:
           include-hidden-files: true
           retention-days: 3
 
+      - name: Reset protobuf compiler cache stats
+        shell: bash
+        run: sccache --zero-stats
+
       - name: Build
-        run: xmake -y
+        # -D keeps the existing XMake compiler-cache diagnostics too.
+        run: xmake -y -D
+
+      - name: Report protobuf compiler cache
+        shell: bash
+        run: sccache --show-stats
+
+      - name: Report Swift module cache
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -d build/.swift-module-cache ]]; then
+            du -sh build/.swift-module-cache
+            echo "files=$(find build/.swift-module-cache -type f | wc -l | tr -d ' ')"
+          else
+            echo "::warning::Swift module cache directory was not created"
+          fi
 
       - name: Verify portable macOS linkage
         shell: bash
@@ -335,6 +480,27 @@ jobs:
         with:
           path: ${{ steps.xmake_cache_paths.outputs.package_dir }}
           key: ${{ steps.restore_packages.outputs.cache-primary-key }}
+
+      - name: Save XMake local packages
+        if: ${{ success() && !cancelled() && steps.restore_local_packages.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: build/.packages
+          key: ${{ steps.restore_local_packages.outputs.cache-primary-key }}
+
+      - name: Save Swift module cache
+        if: ${{ success() && !cancelled() && steps.restore_swift_modules.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: build/.swift-module-cache
+          key: ${{ steps.restore_swift_modules.outputs.cache-primary-key }}
+
+      - name: Save protobuf compiler cache
+        if: ${{ success() && !cancelled() && steps.restore_protobuf_sccache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: build/.protobuf-sccache
+          key: ${{ steps.restore_protobuf_sccache.outputs.cache-primary-key }}
 
       - name: Save XMake compiler cache
         if: ${{ success() && !cancelled() && steps.restore_build.outputs.cache-hit != 'true' }}

--- a/macos-launcher/xmake.lua
+++ b/macos-launcher/xmake.lua
@@ -38,7 +38,14 @@ target("macOSLauncher")
     add_values("xcode.product_name", "STFC Community Mod")
     add_values("xcode.bundle_info_plist", "src/Info.plist")
 
-    add_scflags("-Xcc -fmodules", "-Xcc -fmodule-map-file=macos-launcher/src/module.modulemap", "-D SWIFT_PACKAGE", {force = true})
+    -- Keep imported Swift/Clang modules in a stable path that CI can persist.
+    local swift_module_cache = path.join(os.projectdir(), "build", ".swift-module-cache")
+    add_scflags(
+        "-module-cache-path", swift_module_cache,
+        "-Xcc -fmodules",
+        "-Xcc -fmodule-map-file=macos-launcher/src/module.modulemap",
+        "-D SWIFT_PACKAGE",
+        {force = true})
 
     -- Generate Info.plist from template during configuration
     on_config(function (target)

--- a/mods/xmake.lua
+++ b/mods/xmake.lua
@@ -85,7 +85,11 @@ do
 
     -- Packages
     add_packages("spud", "nlohmann_json", "protobuf", "libil2cpp", "eastl", "toml++", "spdlog", "simdutf", "libcurl", "capstone", "cpr")
-    add_rules("protobuf.cpp")
+    if os.getenv("STFC_PROTOBUF_SCCACHE") == "1" then
+        add_rules("stfc.protobuf.cpp.sccache")
+    else
+        add_rules("protobuf.cpp")
+    end
     add_files("src/prime/proto/*.proto")
 
     set_exceptions("cxx")

--- a/xmake.lua
+++ b/xmake.lua
@@ -21,4 +21,5 @@ add_rules("mode.debug")
 add_rules("mode.release")
 add_rules("mode.releasedbg")
 
+includes("xmake/rules/protobuf_sccache.lua")
 includes("mods")

--- a/xmake/dependencies/common.lua
+++ b/xmake/dependencies/common.lua
@@ -2,6 +2,10 @@
 -- developer machines and CI runners.
 set_policy("package.requires_lock", true)
 
+-- Cold CI configuration is dominated by CMake-backed dependency builds.
+-- Ninja gives those package builds a fast, parallel generator.
+set_policy("package.cmake_generator.ninja", true)
+
 add_repositories("stfc-community-mod-repo xmake-packages")
 
 package("libil2cpp")

--- a/xmake/rules/protobuf_sccache.lua
+++ b/xmake/rules/protobuf_sccache.lua
@@ -1,0 +1,167 @@
+-- Narrow CI experiment for XMake 3.1.0's protobuf.cpp rule.
+-- Generation behavior stays the same; only generated C++ compilation is
+-- wrapped with sccache so the experiment does not affect ordinary C++/Swift.
+--
+-- Keep all runtime logic inside XMake rule callbacks. XMake sandboxes/forks
+-- callback functions, and top-level helper functions do not reliably retain
+-- sandbox globals such as assert/imported modules in XMake 3.1.0.
+
+rule("stfc.protobuf.cpp.sccache")
+    add_deps("c++")
+    set_extensions(".proto")
+
+    after_load(function(target)
+        local sourcebatch = target:sourcebatches()["stfc.protobuf.cpp.sccache"]
+        for _, sourcefile_proto in ipairs(sourcebatch and sourcebatch.sourcefiles or {}) do
+            local fileconfig = target:fileconfig(sourcefile_proto)
+            assert(not (fileconfig and fileconfig.proto_grpc_cpp_plugin),
+                "stfc.protobuf.cpp.sccache does not support proto_grpc_cpp_plugin")
+
+            local prefixdir = fileconfig and fileconfig.proto_rootdir
+            local autogendir = fileconfig and fileconfig.proto_autogendir
+            local rootdir = autogendir or path.join(target:autogendir(), "rules", "protobuf")
+            local filename = path.basename(sourcefile_proto) .. ".pb.cc"
+            local sourcefile_cx = target:autogenfile(sourcefile_proto, {
+                rootdir = rootdir,
+                filename = filename
+            })
+            local sourcefile_dir = prefixdir and path.join(rootdir, prefixdir)
+                or path.directory(sourcefile_cx)
+
+            target:add("includedirs", sourcefile_dir, {
+                public = fileconfig and fileconfig.proto_public or nil
+            })
+            table.insert(target:objectfiles(), target:objectfile(sourcefile_cx))
+        end
+    end)
+
+    on_preparecmd_file(function(target, batchcmds, sourcefile_proto, opt)
+        local find_tool = import("lib.detect.find_tool")
+
+        local fileconfig = target:fileconfig(sourcefile_proto)
+        assert(not (fileconfig and fileconfig.proto_grpc_cpp_plugin),
+            "stfc.protobuf.cpp.sccache does not support proto_grpc_cpp_plugin")
+
+        local prefixdir = fileconfig and fileconfig.proto_rootdir
+        local autogendir = fileconfig and fileconfig.proto_autogendir
+        local rootdir = autogendir or path.join(target:autogendir(), "rules", "protobuf")
+        local filename = path.basename(sourcefile_proto) .. ".pb.cc"
+        local sourcefile_cx = target:autogenfile(sourcefile_proto, {
+            rootdir = rootdir,
+            filename = filename
+        })
+        local sourcefile_dir = prefixdir and path.join(rootdir, prefixdir)
+            or path.directory(sourcefile_cx)
+
+        local protoc = target:data("stfc.protobuf.protoc")
+        if not protoc then
+            local tool = find_tool("protoc", {envs = target:pkgenvs()})
+            protoc = assert(tool and tool.program, "protoc not found!")
+            target:data_set("stfc.protobuf.protoc", protoc)
+        end
+
+        local protoc_args = {
+            sourcefile_proto,
+            "-I" .. (prefixdir or path.directory(sourcefile_proto)),
+            "--cpp_out=" .. sourcefile_dir
+        }
+        if fileconfig and fileconfig.proto_flags then
+            table.join2(protoc_args, fileconfig.proto_flags)
+        end
+
+        batchcmds:mkdir(sourcefile_dir)
+        batchcmds:show_progress(opt.progress,
+            "${color.build.object}compiling.proto.c++ %s", sourcefile_proto)
+        batchcmds:vrunv(protoc, protoc_args, {envs = target:pkgenvs()})
+
+        -- Preserve XMake 3.1.0's protobuf generation dependency behavior.
+        batchcmds:add_depfiles(sourcefile_proto)
+        batchcmds:set_depcache(target:dependfile(sourcefile_cx))
+        batchcmds:set_depmtime(os.mtime(sourcefile_cx))
+    end)
+
+    on_buildcmd_file(function(target, batchcmds, sourcefile_proto, opt)
+        local compiler = import("core.tool.compiler")
+        local find_tool = import("lib.detect.find_tool")
+
+        local fileconfig = target:fileconfig(sourcefile_proto)
+        assert(not (fileconfig and fileconfig.proto_grpc_cpp_plugin),
+            "stfc.protobuf.cpp.sccache does not support proto_grpc_cpp_plugin")
+
+        local prefixdir = fileconfig and fileconfig.proto_rootdir
+        local autogendir = fileconfig and fileconfig.proto_autogendir
+        local rootdir = autogendir or path.join(target:autogendir(), "rules", "protobuf")
+        local filename = path.basename(sourcefile_proto) .. ".pb.cc"
+        local sourcefile_cx = target:autogenfile(sourcefile_proto, {
+            rootdir = rootdir,
+            filename = filename
+        })
+        local sourcefile_dir = prefixdir and path.join(rootdir, prefixdir)
+            or path.directory(sourcefile_cx)
+        local objectfile = target:objectfile(sourcefile_cx)
+
+        local compiler_inst = compiler.load("cxx", {target = target})
+
+        -- rawargs is important on Windows: sccache, not cl.exe, is the immediate
+        -- child process and must receive the logical compiler arguments once.
+        local compiler_program, compiler_argv = compiler_inst:compargv(
+            sourcefile_cx,
+            path(objectfile),
+            {
+                target = target,
+                configs = {includedirs = sourcefile_dir},
+                rawargs = true
+            })
+
+        -- XMake 3.1.0 includes target.frameworks in C++ object flags, so the
+        -- macOS target contributes "-framework Cocoa" even when compiling a
+        -- generated protobuf translation unit. clang accepts that link-only
+        -- pair during -c, but sccache 0.17.0 does not model -framework as an
+        -- option-with-value and therefore mistakes "Cocoa" for another input
+        -- file. Strip only these link-only framework pairs from protobuf
+        -- compilation; keep -F/-iframework search paths and target linkage.
+        if target:is_plat("macosx") then
+            local filtered_argv = {}
+            local skip_framework_name = false
+            for _, arg in ipairs(compiler_argv) do
+                if skip_framework_name then
+                    skip_framework_name = false
+                elseif arg == "-framework" then
+                    skip_framework_name = true
+                else
+                    table.insert(filtered_argv, arg)
+                end
+            end
+            assert(not skip_framework_name, "missing framework name after -framework")
+            compiler_argv = filtered_argv
+        end
+
+        local sccache = target:data("stfc.protobuf.sccache")
+        if not sccache then
+            -- sccache-action exports the exact executable path. Prefer it over
+            -- PATH probing so compiler-specific run environments cannot hide it.
+            sccache = os.getenv("SCCACHE_PATH")
+            if not sccache or sccache == "" then
+                local tool = find_tool("sccache", {norun = true})
+                sccache = tool and tool.program or nil
+            end
+            sccache = assert(sccache,
+                "STFC_PROTOBUF_SCCACHE=1 but sccache was not found")
+            target:data_set("stfc.protobuf.sccache", sccache)
+        end
+
+        local sccache_args = {compiler_program}
+        table.join2(sccache_args, compiler_argv)
+
+        batchcmds:mkdir(path.directory(objectfile))
+        batchcmds:show_progress(opt.progress,
+            "${color.build.object}sccache compiling.proto.$(mode) %s", sourcefile_cx)
+        batchcmds:vrunv(sccache, sccache_args, {envs = compiler_inst:runenvs()})
+
+        -- Preserve the built-in rule's incremental metadata. Cross-run reuse is
+        -- owned by sccache, whose key is based on compiler + args + preprocessed
+        -- input, rather than these mtimes.
+        batchcmds:add_depfiles(sourcefile_proto)
+        batchcmds:set_depcache(target:dependfile(objectfile))
+        batchcmds:set_depmtime(os.mtime(objectfile))
+    end)


### PR DESCRIPTION
## Summary

Improves CI cache coverage on Windows and macOS, with substantial reductions in warm macOS build times.

The main changes are:

- Cache the XMake installation.
- Cache global XMake packages.
- Cache project-local XMake packages under `build/.packages`.
- Pin the macOS deployment target to 13.5.
- Persist XMake's compiler cache on macOS.
- Persist the Swift/Clang module cache on macOS.
- Add a narrowly scoped sccache-backed protobuf rule for generated `.pb.cc` compilation.
- Persist the protobuf sccache between runs on Windows and macOS.
- Add deterministic cache invalidation based on the relevant toolchain, architecture, build configuration, dependency, and protobuf inputs.

## Protobuf caching

XMake 3.1.0's built-in `protobuf.cpp` rule compiles generated C++ through a custom compile path that bypasses XMake's normal compiler-cache path.

This meant generated protobuf sources were recompiled on every fresh runner even when the rest of the C++ build was warm.

Windows has an additional limitation: XMake intentionally disables its own compiler cache for MSVC `cl.exe`.

This PR adds a custom protobuf rule that preserves XMake's protobuf generation/dependency behavior while routing only the generated C++ compilation through sccache.

Normal C++, Swift, build parallelism, and the existing release configuration are otherwise left unchanged.

### macOS framework handling

XMake includes target framework arguments such as `-framework Cocoa` in the generated C++ compile arguments.

sccache 0.17.0 does not parse `-framework <name>` as a compiler option/value pair and consequently interpreted `Cocoa` as another input file.

The custom protobuf rule strips only these link-only `-framework <name>` pairs from protobuf compilation.

Framework search paths and final target linkage are unchanged.

## Warm-cache results

Original warm-cache run:

https://github.com/netniV/stfc-mod/actions/runs/31734703021

Final warm-cache validation:

https://github.com/darbyjack/stfc-mod/actions/runs/31828759614

| Platform | Upstream warm cache | Final warm cache | Change |
|---|---:|---:|---:|
| Windows x64 | 471s | 249s | 47.1% faster |
| macOS ARM64 | 209.102s | 49.784s | 76.2% faster |
| macOS x86_64 | 184.570s | 72.864s | 60.5% faster |

GitHub-hosted runners showed noticeable run-to-run variance, particularly on Windows and ARM64, so the Windows result should be considered effectively unchanged rather than a regression or improvement.

The macOS improvements were substantial and repeatable across warm-cache validation runs.

## Cache validation

On the final unchanged-SHA warm run, protobuf sccache reported the following on Windows x64, macOS ARM64, and macOS x86_64:

- 15 compile requests
- 15 cache hits
- 0 cache misses
- 0 cache errors
- 0 non-cacheable calls

This also confirms persistent protobuf caching works with MSVC even though XMake's own MSVC compiler cache is disabled.

## Correctness

Cache keys include the relevant architecture, toolchain/build configuration, dependency inputs, and source/build-rule inputs so incompatible results are not reused.

The existing macOS compiler cache and Swift module cache remain separate from the protobuf cache.

macOS linkage validation continues to pass after the protobuf compiler-argument adjustment, including the expected system framework dependencies and without introducing Homebrew OpenSSL or libcurl dependencies.